### PR TITLE
Fix coverage stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Tests and Lint
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - "main"
 
 jobs:
   build:
@@ -26,7 +29,6 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV}}
         files: coverage.xml
         fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
The coverage must run in the push to main branch.
It will give the accurated stats in the Codecov

Remove the token for codecov

Closes #78

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>