### PR TITLE
Update pipenv commands and add requirements tox run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ tests:
 	tox -r
 
 requirements:
-	pipenv lock -r > requirements.txt
-	pipenv lock -r -d > requirements-dev.txt
+	pipenv requirements > requirements.txt
+	pipenv requirements --dev > requirements-dev.txt
 
 coverage:
 	coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,lint,test
+envlist = py39,py310,lint,requirements,test
 
 [flake8]
 exclude = ownca/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
@@ -30,6 +30,17 @@ commands =
     coverage xml -i
     coverage report
 
+[testenv:requirements]
+description="Check if `make requirements` is up-to-date."
+deps = pipenv
+skipsdist=false
+allowlist_externals =
+    bash
+commands =
+    pipenv --version
+    bash -c 'diff requirements.txt <(pipenv requirements)'
+    bash -c 'diff requirements-dev.txt <(pipenv requirements --dev)'
+
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt
 commands =
@@ -39,5 +50,5 @@ commands =
 
 [gh-actions]
 python =
-    3.9: py39,pep8,lint,test
-    3.10: py310,pep8,lint,test
+    3.9: py39,pep8,lint,requirements,test
+    3.10: py310,pep8,lint,requirements,test


### PR DESCRIPTION
Fixes #73

The changes in this pr are as follows:
1. update the `pipenv` command in `Makefile`
2. update the `requirements` files content
3. add a tox ci test where we check if there is a new dependency or version of a dependency that should be added to any of the requirements files.

PS: These changes in this pr were first discussed here: https://github.com/vmware/repository-service-tuf-api/pull/124