### PR TITLE
Removes deprecated repository metadata.

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -19,7 +19,6 @@ import enum
 import importlib
 import logging
 import time
-import warnings
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
@@ -354,16 +353,6 @@ class MetadataRepository:
                 time.sleep(3)
             else:
                 return None
-
-    def add_initial_metadata(
-        self,
-        payload: Dict[str, Dict[str, Any]],
-        update_state: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        warnings.warn(
-            "Use bootstrap instead add_initial_metadata", DeprecationWarning
-        )
-        return self.bootstrap(payload, update_state)
 
     def bootstrap(
         self,


### PR DESCRIPTION
The RSTUF worker is deprecating `add_initial_metadata` and replacing by `bootstrap`.

This patch removes part of the code that was used by the deprecated function `add_initial_metadata`.

That was removed from the repository-service-tuf-api issue #108

See PR #129 https://github.com/vmware/repository-service-tuf-api/pull/129

Closes #57 

[Edited]

Signed-off-by: juniorlpa <luiz.pandradejr@gmail.com>