### PR TITLE
Pin hashes for GitHub actions in workflow yml files

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,29 +12,29 @@ jobs:
 
     steps:
     - name: Checkout release tag
-      uses: actions/checkout@v3
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
       with:
         python-version: '3.10'
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
         context: .
         push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         python-versions: [ "3.9", "3.10", ]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+    - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
       with:
         python-version: ${{ matrix.python-versions }}
 
@@ -27,7 +27,7 @@ jobs:
       run: tox
 
     - name: Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
       with:
         files: coverage.xml
         fail_ci_if_error: false

--- a/.github/workflows/publish_docker_dev.yml
+++ b/.github/workflows/publish_docker_dev.yml
@@ -20,26 +20,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+    - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
       with:
         python-version: '3.10'
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
         context: .
         push: true

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -9,19 +9,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+    - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
       with:
         python-version: '3.10'
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
 
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
         context: .
         push: false


### PR DESCRIPTION
Fixes: #81 #82

Pines hash for GitHub actions in workflow yml files.
This will allow dependabot to update our actions by using hashes
as well.

I checked the latest stable versions for each of our action dependencies and got the commit hashes.
I have done a check for security advisories for each of the actions, but haven't found any.

The versions I have used for each of the actions are as follows:
- [actions/checkout v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)
- [actions/setup-python v4.3.0](https://github.com/actions/setup-python/releases/tag/v4.3.0)
- [docker/setup-qemu-action v2.1.0](https://github.com/docker/setup-qemu-action/releases/tag/v2.1.0)
- [docker/setup-buildx-action v2.2.1](https://github.com/docker/setup-buildx-action/releases/tag/v2.2.1)
- [docker/login-action v2.1.0](https://github.com/docker/login-action/releases/tag/v2.1.0)
- [docker/build-push-action v3.2.0](https://github.com/docker/build-push-action/releases/tag/v3.2.0)
- [codecov/codecov-action v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>