### PR TITLE
Add pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: check-added-large-files
+  - id: end-of-file-fixer
+    files: 'repository_service_tuf_worker/'
+  - id: trailing-whitespace
+    files: 'repository_service_tuf_worker/'
+  - id: check-yaml
+    files: '.github/'
+- repo: https://github.com/pycqa/flake8
+  rev: '5.0.4'
+  hooks:
+  - id: flake8
+    exclude: repository_service_tuf_worker/__init__.py|venv|.venv|setting.py|.git|.tox|dist|docs|/*lib/python*|/*egg|build|tools
+- repo: https://github.com/PyCQA/isort
+  rev: '5.10.1'
+  hooks:
+  - id: isort
+    args: [-l79, --profile, black, --check, --diff, .]
+- repo: https://github.com/psf/black
+  rev: '22.10.0'
+  hooks:
+  - id: black
+    args: [-l79, --check, --diff, .]
+- repo: local
+  hooks:
+    - id: tox-requirements
+      name: run requirements check from tox
+      description: Checks if `make requirements` is up-to-date
+      entry: tox -e requirements
+      language: system
+      files: ''
+      verbose: true

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ requirements:
 	pipenv requirements > requirements.txt
 	pipenv requirements --dev > requirements-dev.txt
 
+precommit:
+	pre-commit install
+	pre-commit autoupdate
+	pre-commit run --all-files --show-diff-on-failure
+
 coverage:
 	coverage report
 	coverage html -i

--- a/Pipfile
+++ b/Pipfile
@@ -80,6 +80,7 @@ sphinxcontrib-plantuml = "==0.24"
 sphinxcontrib-qthelp = "==1.0.3"
 sphinxcontrib-serializinghtml = "==1.1.5"
 myst-parser = "*"
+pre-commit = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bb1526056ab15756ed7b3da49178dcb867390ebaa8322a247e8ecdc0941a1ace"
+            "sha256": "bcd5ea03bb0eeb08a928aa442290742e981eb0f0a58bf50964bcd79d6dc67255"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -129,7 +129,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "click": {
@@ -145,7 +145,7 @@
                 "sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667",
                 "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"
             ],
-            "markers": "python_full_version >= '3.6.2' and python_full_version < '4.0.0'",
+            "markers": "python_version < '4' and python_full_version >= '3.6.2'",
             "version": "==0.3.0"
         },
         "click-plugins": {
@@ -631,12 +631,20 @@
             ],
             "version": "==1.15.1"
         },
+        "cfgv": {
+            "hashes": [
+                "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426",
+                "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==3.3.1"
+        },
         "charset-normalizer": {
             "hashes": [
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "click": {
@@ -652,7 +660,7 @@
                 "sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667",
                 "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"
             ],
-            "markers": "python_full_version >= '3.6.2' and python_full_version < '4.0.0'",
+            "markers": "python_version < '4' and python_full_version >= '3.6.2'",
             "version": "==0.3.0"
         },
         "click-plugins": {
@@ -813,6 +821,14 @@
             ],
             "index": "pypi",
             "version": "==5.0.4"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:6c32dbd747aa4ceee1df33f25fed0b0f6e0d65721b15bd151307ff7056d50245",
+                "sha256:b276db7ec52d7e89f5bc4653380e33054ddc803d25875952ad90b0f012cbcdaa"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.6"
         },
         "idna": {
             "hashes": [
@@ -985,6 +1001,14 @@
             "index": "pypi",
             "version": "==0.18.1"
         },
+        "nodeenv": {
+            "hashes": [
+                "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e",
+                "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==1.7.0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -1016,6 +1040,14 @@
             ],
             "index": "pypi",
             "version": "==1.0.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7",
+                "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"
+            ],
+            "index": "pypi",
+            "version": "==2.20.0"
         },
         "pretend": {
             "hashes": [
@@ -1180,6 +1212,14 @@
             ],
             "markers": "python_version ~= '3.7'",
             "version": "==0.25.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17",
+                "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==65.5.0"
         },
         "six": {
             "hashes": [

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ you stay up-to-date with our repository:
     git merge upstream/main
 
 
-Intalling project requirements
+Installing project requirements
 ==============================
 
 This repository has the ``requirements.txt`` and the ``requirements-dev.txt``
@@ -98,6 +98,21 @@ Install development requirements
         $ pip uninstall cryptography cffi -y
         $ pip cache purge
         $ LDFLAGS=-L$(brew --prefix libffi)/lib CFLAGS=-I$(brew --prefix libffi)/include pip install cffi cryptography
+
+
+Running checks with pre-commit:
+
+The pre-commit tool is installed as part of the development requirements.
+
+To automatically run checks before you commit your changes you should run:
+
+.. code:: shell
+
+    $ make precommit
+
+This will install the git hook scripts for the first time, it will update to the
+latest versions of the hooks and run the pre-commit tool.
+Now ``pre-commit`` will run automatically on ``git commit``.
 
 
 Running the development Worker locally
@@ -151,16 +166,3 @@ Updating requirements files from Pipenv
 .. code:: shell
 
   $ make requirements
-
-
-Installing & enabling pre-commit
-================================
-
-The pre-commit tool is installed as part of the development requirements.
-
-To automatically run checks before you commit your changes you should install
-the git hook scripts with **pre-commit**:
-
-.. code:: shell
-
-    $ pre-commit install

--- a/README.rst
+++ b/README.rst
@@ -151,3 +151,16 @@ Updating requirements files from Pipenv
 .. code:: shell
 
   $ make requirements
+
+
+Installing & enabling pre-commit
+================================
+
+The pre-commit tool is installed as part of the development requirements.
+
+To automatically run checks before you commit your changes you should install
+the git hook scripts with **pre-commit**:
+
+.. code:: shell
+
+    $ pre-commit install

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,62 +1,67 @@
 -i https://pypi.org/simple
 alabaster==0.7.12
-amqp==5.1.1 ; python_version >= '3.6'
-async-timeout==4.0.2 ; python_version >= '3.6'
+amqp==5.1.1; python_version >= '3.6'
+async-timeout==4.0.2; python_version >= '3.6'
 attrs==22.1.0
-babel==2.10.3 ; python_version >= '3.6'
+babel==2.10.3; python_version >= '3.6'
 billiard==3.6.4.0
 black==22.6.0
 celery==5.2.7
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.9.24; python_version >= '3.6'
 cffi==1.15.1
-charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
-click==8.1.3 ; python_version >= '3.7'
-click-didyoumean==0.3.0 ; python_full_version >= '3.6.2' and python_full_version < '4.0.0'
+cfgv==3.3.1; python_full_version >= '3.6.1'
+charset-normalizer==2.1.1; python_version >= '3.6'
+click==8.1.3; python_version >= '3.7'
+click-didyoumean==0.3.0; python_version < '4' and python_full_version >= '3.6.2'
 click-plugins==1.1.1
 click-repl==0.2.0
 configobj==5.0.6
 coverage==6.4.4
 cryptography==38.0.1
-deprecated==1.2.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 distlib==0.3.5
-docutils==0.17.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+docutils==0.17.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 dynaconf[ini]==3.1.11
 filelock==3.8.0
 flake8==5.0.4
-idna==3.4 ; python_version >= '3.5'
-imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+identify==2.5.6; python_version >= '3.7'
+idna==3.4; python_version >= '3.5'
+imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 iniconfig==1.1.1
 isort==5.10.1
-jinja2==3.1.2 ; python_version >= '3.7'
-kombu==5.2.4 ; python_version >= '3.7'
-markdown-it-py==2.1.0 ; python_version >= '3.7'
-markupsafe==2.1.1 ; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
+kombu==5.2.4; python_version >= '3.7'
+markdown-it-py==2.1.0; python_version >= '3.7'
+markupsafe==2.1.1; python_version >= '3.7'
 mccabe==0.7.0
-mdit-py-plugins==0.3.1 ; python_version >= '3.7'
-mdurl==0.1.2 ; python_version >= '3.7'
+mdit-py-plugins==0.3.1; python_version >= '3.7'
+mdurl==0.1.2; python_version >= '3.7'
 mypy==0.971
 mypy-extensions==0.4.3
 myst-parser==0.18.1
-packaging==21.3 ; python_version >= '3.6'
+nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==21.3; python_version >= '3.6'
 pathspec==0.9.0
 platformdirs==2.5.2
 pluggy==1.0.0
+pre-commit==2.20.0
 pretend==1.0.9
-prompt-toolkit==3.0.31 ; python_full_version >= '3.6.2'
+prompt-toolkit==3.0.31; python_full_version >= '3.6.2'
 py==1.11.0
 pycodestyle==2.9.1
 pycparser==2.21
 pyflakes==2.5.0
-pygments==2.13.0 ; python_version >= '3.6'
+pygments==2.13.0; python_version >= '3.6'
 pynacl==1.5.0
-pyparsing==3.0.9 ; python_full_version >= '3.6.8'
+pyparsing==3.0.9; python_full_version >= '3.6.8'
 pytest==7.1.2
 pytz==2022.5
-pyyaml==6.0 ; python_version >= '3.6'
+pyyaml==6.0; python_version >= '3.6'
 redis==4.3.4
-requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
-securesystemslib==0.25.0 ; python_version ~= '3.7'
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+requests==2.28.1; python_version >= '3.7' and python_version < '4'
+securesystemslib==0.25.0; python_version ~= '3.7'
+setuptools==65.5.0; python_version >= '3.7'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 snowballstemmer==2.2.0
 sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
@@ -72,11 +77,10 @@ tomli==2.0.1
 tox==3.25.1
 tuf==2.0.0
 typing-extensions==4.3.0
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
-vine==5.0.0 ; python_version >= '3.6'
+urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
+vine==5.0.0; python_version >= '3.6'
 virtualenv==20.16.3
 watchdog==2.1.9
 wcwidth==0.2.5
-wrapt==1.14.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-setuptools==65.5.0 ; python_version >= '3.7'
+wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 supervisor==4.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,36 +1,36 @@
 -i https://pypi.org/simple
-amqp==5.1.1 ; python_version >= '3.6'
-async-timeout==4.0.2 ; python_version >= '3.6'
+amqp==5.1.1; python_version >= '3.6'
+async-timeout==4.0.2; python_version >= '3.6'
 billiard==3.6.4.0
 celery==5.2.7
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.9.24; python_version >= '3.6'
 cffi==1.15.1
-charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
-click==8.1.3 ; python_version >= '3.7'
-click-didyoumean==0.3.0 ; python_full_version >= '3.6.2' and python_full_version < '4.0.0'
+charset-normalizer==2.1.1; python_version >= '3.6'
+click==8.1.3; python_version >= '3.7'
+click-didyoumean==0.3.0; python_version < '4' and python_full_version >= '3.6.2'
 click-plugins==1.1.1
 click-repl==0.2.0
 configobj==5.0.6
 cryptography==38.0.1
-deprecated==1.2.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 dynaconf[ini]==3.1.11
-idna==3.4 ; python_version >= '3.5'
-kombu==5.2.4 ; python_version >= '3.7'
-packaging==21.3 ; python_version >= '3.6'
-prompt-toolkit==3.0.31 ; python_full_version >= '3.6.2'
+idna==3.4; python_version >= '3.5'
+kombu==5.2.4; python_version >= '3.7'
+packaging==21.3; python_version >= '3.6'
+prompt-toolkit==3.0.31; python_full_version >= '3.6.2'
 pycparser==2.21
 pynacl==1.5.0
-pyparsing==3.0.9 ; python_full_version >= '3.6.8'
+pyparsing==3.0.9; python_full_version >= '3.6.8'
 pytz==2022.5
 redis==4.3.4
-requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
-securesystemslib==0.25.0 ; python_version ~= '3.7'
-setuptools==65.5.0 ; python_version >= '3.7'
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+requests==2.28.1; python_version >= '3.7' and python_version < '4'
+securesystemslib==0.25.0; python_version ~= '3.7'
+setuptools==65.5.0; python_version >= '3.7'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 supervisor==4.2.4
 tuf==2.0.0
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
-vine==5.0.0 ; python_version >= '3.6'
+urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
+vine==5.0.0; python_version >= '3.6'
 watchdog==2.1.9
 wcwidth==0.2.5
-wrapt==1.14.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py39,py310,lint,requirements,test
 
 [flake8]
-exclude = ownca/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
+exclude = repository_service_tuf_worker/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
 
 [testenv]
 setenv =
@@ -19,10 +19,11 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
 
 [testenv:lint]
+deps = pre-commit
 commands =
-    flake8
-    isort -l79 --profile black --check --diff .
-    black -l79 --check --diff .
+    pre-commit run flake8 --all-files --show-diff-on-failure
+    pre-commit run isort --all-files --show-diff-on-failure
+    pre-commit run black --all-files --show-diff-on-failure
 
 [testenv:test]
 commands =
@@ -38,8 +39,8 @@ allowlist_externals =
     bash
 commands =
     pipenv --version
-    bash -c 'diff requirements.txt <(pipenv requirements)'
-    bash -c 'diff requirements-dev.txt <(pipenv requirements --dev)'
+    bash -c 'diff -w requirements.txt <(pipenv requirements)'
+    bash -c 'diff -w requirements-dev.txt <(pipenv requirements --dev)'
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt


### PR DESCRIPTION
In this PR, we add the pre-commit tool to
improve the Software Development Lifecycle
of the project by automatically running checks
(mainly linting & formatting) before one commits their changes.

- Specifically:
* flake8, isort and black were adjusted in tox to run as a pre-commit hooks
* Additionally, added hooks were:
 - the check-added-large-files - prevents giant files from being committed
 - end-of-file-fixer - ensures that a file is either empty or ends with one newline
 - trailing-whitespace - trims trailing whitespace
 - check-yaml - checks yaml files for parseable syntax
* we added a local hook with pre-commit that calls tox to check if `make requirements` is up-to-date

- The Pipfile dev-packages were updated to include pre-commit.

- We updated the README.md with how to install and enable pre-commit.

- We ran `make requirements`.

- Fix tox requirements check failing