### PR TITLE
workaround: fix sslib compatiblity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 
 purge:
 	$(MAKE) clean
-	docker rmi repository-service-tuf-worker_repository-service-tuf-worker --force
+	docker rmi tuf-repository-service-worker_repository-service-tuf-worker --force
 
 reformat:
 	black -l 79 .

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ redis = "*"
 tuf = "==2.0.0"
 dynaconf = {extras = ["ini"], version = "*"}
 supervisor = "*"
+securesystemslib = "==0.23.0"
 
 [dev-packages]
 tox = "==3.25.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bb1526056ab15756ed7b3da49178dcb867390ebaa8322a247e8ecdc0941a1ace"
+            "sha256": "42705a00e1000e536c17258715dc5bda39d406022dcbebeaa34b4afb8a528526"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -307,11 +307,11 @@
         },
         "securesystemslib": {
             "hashes": [
-                "sha256:04bc11593edd68405939d3dfc318080bfb31f1ebb5d81c7911914b42dfd4bf2f",
-                "sha256:10d5a066e70cb87704c9bf2cef1ef6d8a06fab5ef7602dd59c26d06251317a11"
+                "sha256:573e9c810f2a6afe9ac71a177f26b9d6a321c53574f561f5cef2ed511c3f1831",
+                "sha256:613c2891a8b4480bae6edb2351710f8c695679101ea7f471cc56f64980d2cd38"
             ],
-            "markers": "python_version ~= '3.7'",
-            "version": "==0.25.0"
+            "index": "pypi",
+            "version": "==0.23.0"
         },
         "setuptools": {
             "hashes": [
@@ -1175,11 +1175,11 @@
         },
         "securesystemslib": {
             "hashes": [
-                "sha256:04bc11593edd68405939d3dfc318080bfb31f1ebb5d81c7911914b42dfd4bf2f",
-                "sha256:10d5a066e70cb87704c9bf2cef1ef6d8a06fab5ef7602dd59c26d06251317a11"
+                "sha256:573e9c810f2a6afe9ac71a177f26b9d6a321c53574f561f5cef2ed511c3f1831",
+                "sha256:613c2891a8b4480bae6edb2351710f8c695679101ea7f471cc56f64980d2cd38"
             ],
-            "markers": "python_version ~= '3.7'",
-            "version": "==0.25.0"
+            "index": "pypi",
+            "version": "==0.23.0"
         },
         "six": {
             "hashes": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -55,7 +55,7 @@ pytz==2022.5
 pyyaml==6.0 ; python_version >= '3.6'
 redis==4.3.4
 requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
-securesystemslib==0.25.0 ; python_version ~= '3.7'
+securesystemslib==0.23.0
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 snowballstemmer==2.2.0
 sphinx==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pyparsing==3.0.9 ; python_full_version >= '3.6.8'
 pytz==2022.5
 redis==4.3.4
 requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
-securesystemslib==0.25.0 ; python_version ~= '3.7'
+securesystemslib==0.23.0
 setuptools==65.5.0 ; python_version >= '3.7'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 supervisor==4.2.4


### PR DESCRIPTION
It is a workaround for `securesystemslib` compatibility with rstuf-worker.

The securesystemslib version 0.25.0 is not working with rstuf-worker v0.0.1a2.

Workaround for bug #118

(Fix `make purge`, wrong container image reference)

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>