### PR TITLE
Add vscode settings folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VScode settings folder
+.vscode


### PR DESCRIPTION
Add vscode settings folder to .gitignore.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>