### PR TITLE
build: functional tests before release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,15 @@ on:
       - v*
 
 jobs:
+  functional-latest:
+    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@simplify_functional
+    with:
+      worker_version: dev
+      api_version: latest
+      cli_version: latest
+
   release:
+    needs: functional-latest
     runs-on: ubuntu-latest
 
     steps:
@@ -39,8 +47,8 @@ jobs:
       with:
         context: .
         tags: |
-            ghcr.io/vmware/repository-service-tuf-worker:latest
             ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
+            ghcr.io/vmware/repository-service-tuf-worker:latest
         outputs: type=docker,dest=/tmp/repository-service-tuf-worker_${{ github.ref_name }}.tar
         cache-to: type=local,dest=/tmp/rstuf_worker_cache
 
@@ -51,8 +59,8 @@ jobs:
         context: .
         push: true
         tags: |
-            ghcr.io/vmware/repository-service-tuf-worker:latest
             ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
+            ghcr.io/vmware/repository-service-tuf-worker:latest
         cache-from: type=local,src=/tmp/rstuf_worker_cache
 
     - name: Publish GitHub Release

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   functional-latest:
-    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@simplify_functional
+    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
     with:
       worker_version: dev
       api_version: latest


### PR DESCRIPTION
When a release is trigged, it uses the functional tests from vmware/repository-service-tuf (umbrella repository).

The release is build/published if the functional tests are ok.

Closes #117 

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>