### PR TITLE
fix: choose specific names for automated PRs

### DIFF
--- a/.github/workflows/update-python-deps.yml
+++ b/.github/workflows/update-python-deps.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "build: Update Python dependencies"
+          branch: "rstuf-bot/update-python-dependencies"
+          delete-branch: true
           title: "build: Update Python dependencies"
           body: >
             The following PR updates the Python dependencies and generates new pipfile and requirements file.


### PR DESCRIPTION
The following PR sets a specific branch name for our automated PR process of updating dependencies.

Fixes https://github.com/vmware/repository-service-tuf/issues/109