### PR TITLE
Improve unit test coverage

### DIFF
--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -13,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import ABC
+
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from io import TextIOBase
 from typing import Any, Dict, List
@@ -36,53 +37,61 @@ class ServiceSettings:
 
 class IKeyVault(ABC):
     @classmethod
+    @abstractmethod
     def configure(cls, settings):
         """
         Run actions to test, configure using the settings.
         """
-        raise NotImplementedError
+        pass  # pragma: no cover
 
     @classmethod
+    @abstractmethod
     def settings(cls):
         """
         Define all the ServiceSettings required in settings.
         """
-        raise NotImplementedError
+        pass  # pragma: no cover
 
+    @abstractmethod
     def get(self, rolename: List[str]) -> Dict[str, Any]:
         """Return a key from specific rolename."""
-        raise NotImplementedError
+        pass  # pragma: no cover
 
+    @abstractmethod
     def put(self, file_object: str, filename: str) -> None:
         """
         Stores file object with a specific filename.
         """
-        raise NotImplementedError
+        pass  # pragma: no cover
 
 
 class IStorage(StorageBackendInterface):
     @classmethod
+    @abstractmethod
     def configure(cls, settings: Any):
         """
         Run actions to test, configure using the settings.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     @classmethod
+    @abstractmethod
     def settings(cls) -> List[ServiceSettings]:
         """
         Define all the ServiceSettings required in settings.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
+    @abstractmethod
     def get(self, rolename: str, version: int) -> "Metadata[T]":
         """
         Return metadata from specific role name, optionally specific version.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
+    @abstractmethod
     def put(self, file_object: TextIOBase, filename: str) -> None:
         """
         Stores file object with a specific filename.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -366,8 +366,6 @@ class MetadataRepository:
         to the Storage Backend.
         """
         # the update_state is not used for bootstrap
-        if update_state:
-            pass
 
         # Store online keys to the Key Vault
         if settings := payload.get("settings"):

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -42,12 +42,12 @@ class TestLocalStorageService:
         service = local.LocalStorage("/path")
 
         local.glob = pretend.stub(
-            glob=pretend.call_recorder(lambda *a: ["1.root.json"])
+            glob=pretend.call_recorder(lambda *a: ["2.root.json"])
         )
         local.os = pretend.stub(
             path=pretend.stub(
                 join=pretend.call_recorder(
-                    lambda *a, **kw: "/path/1.root.json"
+                    lambda *a, **kw: "/path/2.root.json"
                 )
             )
         )
@@ -65,10 +65,10 @@ class TestLocalStorageService:
         assert result == fake_file_object.read()
         assert fake_file_object.close.calls == [pretend.call()]
         assert fake_file_object.read.calls == [pretend.call(), pretend.call()]
-        assert local.glob.glob.calls == [pretend.call("/path/1.root.json")]
+        assert local.glob.glob.calls == [pretend.call("/path/2.root.json")]
         assert local.os.path.join.calls == [
             pretend.call(service._path, "*.root.json"),
-            pretend.call(service._path, "1.root.json"),
+            pretend.call(service._path, "2.root.json"),
         ]
 
     def test_get_timestamp(self, monkeypatch):
@@ -77,7 +77,7 @@ class TestLocalStorageService:
         local.os = pretend.stub(
             path=pretend.stub(
                 join=pretend.call_recorder(
-                    lambda *a, **kw: "/path/1.root.json"
+                    lambda *a, **kw: "/path/2.root.json"
                 )
             )
         )
@@ -116,6 +116,9 @@ class TestLocalStorageService:
             read=pretend.call_recorder(lambda: b"fake_root_data"),
         )
         monkeypatch.setitem(
+            local.__builtins__, "max", pretend.raiser(ValueError)
+        )
+        monkeypatch.setitem(
             local.__builtins__, "open", lambda *a, **kw: fake_file_object
         )
 
@@ -134,12 +137,12 @@ class TestLocalStorageService:
     def test_get_OSError(self, monkeypatch):
         service = local.LocalStorage("/path")
         local.glob = pretend.stub(
-            glob=pretend.call_recorder(lambda *a: ["1.root.json"])
+            glob=pretend.call_recorder(lambda *a: ["2.root.json"])
         )
         local.os = pretend.stub(
             path=pretend.stub(
                 join=pretend.call_recorder(
-                    lambda *a, **kw: "/path/1.root.json"
+                    lambda *a, **kw: "/path/2.root.json"
                 )
             )
         )
@@ -163,9 +166,9 @@ class TestLocalStorageService:
         assert fake_file_object.read.calls == []
         assert local.os.path.join.calls == [
             pretend.call(service._path, "*.root.json"),
-            pretend.call(service._path, "1.root.json"),
+            pretend.call(service._path, "2.root.json"),
         ]
-        assert local.glob.glob.calls == [pretend.call("/path/1.root.json")]
+        assert local.glob.glob.calls == [pretend.call("/path/2.root.json")]
 
     def test_put(self, monkeypatch):
         service = local.LocalStorage("/path")

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -32,9 +32,9 @@ class TestMetadataRepository:
         assert isinstance(test_repo._settings, repository.Dynaconf) is True
 
     def test_refresh_settings_with_worker_settings_arg(self):
-        FAKE_SETTINGS_FILE = "/data/mysettings.ini"
+        FAKE_SETTINGS_FILE_PATH = "/data/mysettings.ini"
         fake_worker_settings = Dynaconf(
-            settings_files=[FAKE_SETTINGS_FILE],
+            settings_files=[FAKE_SETTINGS_FILE_PATH],
             envvar_prefix="RSTUF",
         )
 


### PR DESCRIPTION
In repository_service_tuf_worker/interfaces.py:
Made coverage ignore (# pragma: no cover) the interfaces' methods that have exceptions in the abstract classes as they will never be raised (a TypeError will be raised instead if an abstract method is not implemented).
The exceptions could be substituted with the "pass" keyword in IStorage(StorageBackendInterface) class, but to keep compatibility with the securesystemslib/storage.py implementation of StorageBackendInterface of the securesystemslib package, we keep it as is.

In tests/unit/tuf_repository_service_worker/services/storage/test_local.py:
- Changed default stub value of version. Stubbed tests for LocalStorage.get should not have default stub for version equal to 1, because that's also the default value when a ValueError exception is called.
- Added stubbing ValueError for max(versions), increasing coverage.

In repository_service_tuf_worker/repository.py there are still some unit tests that can be added (see the miss in coverage).

Closes #9

Signed-off-by: Konstantinos Papadopoulos <konpap1996@yahoo.com>