### PR TITLE
feat: add last_update on tasks information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build-dev:
 
 run-dev:
 	$(MAKE) build-dev
-	docker pull ghcr.io/vmware/repository-service-tuf-api:dev
+	# docker pull ghcr.io/vmware/repository-service-tuf-api:dev
 	docker-compose up --remove-orphans
 
 
@@ -19,7 +19,7 @@ clean:
 
 purge:
 	$(MAKE) clean
-	docker rmi tuf-repository-service-worker_repository-service-tuf-worker --force
+	docker rmi repository-service-tuf-worker_repository-service-tuf-worker --force
 
 reformat:
 	black -l 79 .

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build-dev:
 
 run-dev:
 	$(MAKE) build-dev
-	# docker pull ghcr.io/vmware/repository-service-tuf-api:dev
+	docker pull ghcr.io/vmware/repository-service-tuf-api:dev
 	docker-compose up --remove-orphans
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: always
 
   repository-service-tuf-api:
-    image: ghcr.io/vmware/repository-service-tuf-api:dev
+    image: repository-service-tuf-api:dev
     volumes:
       - repository-service-tuf-api-data:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: always
 
   repository-service-tuf-api:
-    image: repository-service-tuf-api:dev
+    image: ghcr.io/vmware/repository-service-tuf-api:dev
     volumes:
       - repository-service-tuf-api-data:/data
     ports:

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -79,6 +79,7 @@ SPEC_VERSION: str = ".".join(SPECIFICATION_VERSION)
 class ResultDetails:
     status: str
     details: Optional[Dict[str, Any]]
+    last_update: datetime
 
 
 class MetadataRepository:
@@ -335,6 +336,7 @@ class MetadataRepository:
                 meta={
                     "unpublished_roles": unpublised_roles,
                     "status": "Publishing",
+                    "last_update": datetime.now(),
                 },
             )
 
@@ -391,6 +393,7 @@ class MetadataRepository:
             details={
                 "bootstrap": True,
             },
+            last_update=datetime.now(),
         )
 
         return asdict(result)
@@ -447,6 +450,7 @@ class MetadataRepository:
                 "targets": [target.get("path") for target in targets],
                 "target_roles": [t_role for t_role in bin_target_groups],
             },
+            last_update=datetime.now(),
         )
         logging.debug(f"Added targets. {result}")
         return asdict(result)
@@ -507,6 +511,7 @@ class MetadataRepository:
                 "deleted_targets": deleted_targets,
                 "not_found_targets": not_found_targets,
             },
+            last_update=datetime.now(),
         )
 
         logging.debug(f"Delete targets. {result}")


### PR DESCRIPTION
It adds a new field in the responses for the tasks received or updated by the rstuf worker.

This field helps to the requesters manage the tasks based on date time

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>