### PR TITLE
fix: custom redis configuration for the container

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,7 +36,11 @@ class status(Enum):
     FAILURE = "FAILURE"
 
 
-redis_backend = redis.StrictRedis.from_url(worker_settings.REDIS_SERVER)
+redis_backend = redis.StrictRedis.from_url(
+    worker_settings.REDIS_SERVER,
+    port=worker_settings.get("REDIS_SERVER_PORT", 6379),
+    db=worker_settings.get("REDIS_SERVER_DB_RESULT", 0)
+)
 
 # TODO: Issue https://github.com/vmware/vmware/issues/6
 # BROKER_USE_SSL = {
@@ -49,7 +53,11 @@ redis_backend = redis.StrictRedis.from_url(worker_settings.REDIS_SERVER)
 app = Celery(
     f"repository_service_tuf_worker_{worker_settings.WORKER_ID}",
     broker=worker_settings.BROKER_SERVER,
-    backend=worker_settings.REDIS_SERVER,
+    backend=(
+        f"{worker_settings.REDIS_SERVER}"
+        f":{worker_settings.get('REDIS_SERVER_PORT', 6379)}"
+        f"/{worker_settings.get('REDIS_SERVER_DB_RESULT', 0)}"
+    ),
     result_persistent=True,
     task_acks_late=True,
     task_track_started=True,

--- a/app.py
+++ b/app.py
@@ -39,7 +39,7 @@ class status(Enum):
 redis_backend = redis.StrictRedis.from_url(
     worker_settings.REDIS_SERVER,
     port=worker_settings.get("REDIS_SERVER_PORT", 6379),
-    db=worker_settings.get("REDIS_SERVER_DB_RESULT", 0)
+    db=worker_settings.get("REDIS_SERVER_DB_RESULT", 0),
 )
 
 # TODO: Issue https://github.com/vmware/vmware/issues/6

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -64,6 +64,8 @@ Redis Server port number. Default: 6379
 
 Redis Server DB number for Result Backend (tasks). Default: 0
 
+Important: It should use the same db id as used by RSTUF API.
+
 #### (Optional) `RSTUF_REDIS_SERVER_DB_REPO_SETTINGS`
 
 Redis Server DB number for repository settings. Default: 1


### PR DESCRIPTION
The current custom Redis configuration for the RSTUF Worker container doesn't work correctly.

The backend result custom port is not corrrectly parsed for the callbacks (signals) and in the default Celery Backend

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>