### PR TITLE
Remove the BIN role from RSTUF Worker

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -66,7 +66,6 @@ class Roles(enum.Enum):
     TARGETS = Targets.type
     SNAPSHOT = Snapshot.type
     TIMESTAMP = Timestamp.type
-    BIN = "bin"
     BINS = "bins"
 
 
@@ -74,10 +73,8 @@ ALL_REPOSITORY_ROLES_NAMES = [rolename.value for rolename in Roles]
 OFFLINE_KEYS = {
     Roles.ROOT.value.upper(),
     Roles.TARGETS.value.upper(),
-    Roles.BIN.value.upper(),
 }
 
-BIN = "bin"
 BINS = "bins"
 SPEC_VERSION: str = ".".join(SPECIFICATION_VERSION)
 
@@ -318,7 +315,7 @@ class MetadataRepository:
         """
         Return role name by target file path
         """
-        bin_role = self._load(BIN)
+        bin_role = self._load(Targets.type)
         bin_succinct_roles = bin_role.signed.delegations.succinct_roles
         bins_name = bin_succinct_roles.get_role_for_target(target_path)
 
@@ -619,14 +616,14 @@ class MetadataRepository:
         Updating 'bins' also updates 'snapshot' and 'timestamp'.
         """
         try:
-            bin = self._load(BIN)
+            targets = self._load(Targets.type)
         except StorageError:
-            logging.error(f"{BIN} not found, not bumping.")
+            logging.error(f"{Targets.type} not found, not bumping.")
             return False
 
-        bin_succinct_roles = bin.signed.delegations.succinct_roles
+        targets_succinct_roles = targets.signed.delegations.succinct_roles
         targets_meta = []
-        for bins_name in bin_succinct_roles.get_roles():
+        for bins_name in targets_succinct_roles.get_roles():
             bins_role = self._load(bins_name)
 
             if (bins_role.signed.expires - datetime.now()) < timedelta(

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -343,7 +343,7 @@ class TestMetadataRepository:
     def test__get_path_succinct_role(self):
         test_repo = repository.MetadataRepository.create_service()
 
-        fake_bin = pretend.stub(
+        fake_targets = pretend.stub(
             signed=pretend.stub(
                 delegations=pretend.stub(
                     succinct_roles=pretend.stub(
@@ -354,12 +354,12 @@ class TestMetadataRepository:
                 ),
             )
         )
-        test_repo._load = pretend.call_recorder(lambda *a: fake_bin)
+        test_repo._load = pretend.call_recorder(lambda *a: fake_targets)
         result = test_repo._get_path_succinct_role("v0.0.1/test_path.tar.gz")
 
         assert result == "bin-e"
         assert (
-            fake_bin.signed.delegations.succinct_roles.get_role_for_target.calls  # noqa
+            fake_targets.signed.delegations.succinct_roles.get_role_for_target.calls  # noqa
             == [pretend.call("v0.0.1/test_path.tar.gz")]
         )
 
@@ -1003,7 +1003,7 @@ class TestMetadataRepository:
     def test_bump_bins_roles(self):
         test_repo = repository.MetadataRepository.create_service()
 
-        fake_bin = pretend.stub(
+        fake_targets = pretend.stub(
             signed=pretend.stub(
                 delegations=pretend.stub(
                     succinct_roles=pretend.stub(
@@ -1019,8 +1019,8 @@ class TestMetadataRepository:
         )
 
         def mocked_load(role):
-            if role == "bin":
-                return fake_bin
+            if role == "targets":
+                return fake_targets
             else:
                 return fake_bins
 
@@ -1044,7 +1044,7 @@ class TestMetadataRepository:
         result = test_repo.bump_bins_roles()
         assert result is True
         assert test_repo._load.calls == [
-            pretend.call("bin"),
+            pretend.call("targets"),
             pretend.call("bin-a"),
         ]
         assert test_repo._bump_version.calls == [pretend.call(fake_bins)]
@@ -1063,7 +1063,7 @@ class TestMetadataRepository:
     def test_bump_bins_roles_no_changes(self):
         test_repo = repository.MetadataRepository.create_service()
 
-        fake_bin = pretend.stub(
+        fake_targets = pretend.stub(
             signed=pretend.stub(
                 delegations=pretend.stub(
                     succinct_roles=pretend.stub(
@@ -1079,8 +1079,8 @@ class TestMetadataRepository:
         )
 
         def mocked_load(role):
-            if role == "bin":
-                return fake_bin
+            if role == "targets":
+                return fake_targets
             else:
                 return fake_bins
 
@@ -1089,7 +1089,7 @@ class TestMetadataRepository:
         result = test_repo.bump_bins_roles()
         assert result is True
         assert test_repo._load.calls == [
-            pretend.call("bin"),
+            pretend.call("targets"),
             pretend.call("bin-a"),
         ]
 


### PR DESCRIPTION
As described in the feature https://github.com/vmware/repository-service-tuf/issues/28 we no longer need the BIN role.
We can remove all mentions and usages of it and instead use the top-level targets role to do its purpose and use succinct hash bin delegation.

It will be wise if we first merge:
- https://github.com/vmware/repository-service-tuf-api/pull/226
- https://github.com/vmware/repository-service-tuf-cli/pull/175

Close #165

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>