### PR TITLE
chore: query unpublished role names ordered

### DIFF
--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -30,6 +30,7 @@ def read_unpublished_rolenames(db: Session) -> Tuple[bool, str]:
         .filter(
             models.RSTUFTargets.published == False,  # noqa
         )
+        .order_by(models.RSTUFTargets.rolename)
         .distinct()
         .all()
     )

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -46,8 +46,11 @@ class TestTargetsCrud:
         mocked_distinct = pretend.stub(
             distinct=pretend.call_recorder(lambda: mocked_all)
         )
+        mocked_order_by = pretend.stub(
+            order_by=pretend.call_recorder(lambda *a: mocked_distinct)
+        )
         mocked_filter = pretend.stub(
-            filter=pretend.call_recorder(lambda *a: mocked_distinct)
+            filter=pretend.call_recorder(lambda *a: mocked_order_by)
         )
         mocked_db = pretend.stub(
             query=pretend.call_recorder(lambda *a: mocked_filter)
@@ -58,6 +61,7 @@ class TestTargetsCrud:
         assert test_result == [(False, "bin-e"), (False, "bin-3")]
         assert mocked_db.query.calls == [pretend.call(False, "all-bins")]
         assert mocked_filter.filter.calls == [pretend.call(True)]
+        assert mocked_order_by.order_by.calls == [pretend.call("all-bins")]
         assert mocked_distinct.distinct.calls == [pretend.call()]
         assert mocked_all.all.calls == [pretend.call()]
 


### PR DESCRIPTION
This commit doesn't change the logic of the implementations that uses this specific crud, just get the role names ordered by the delegated hash bin role names.

In the case of debugging, it will help to understand the flow.

Closes #117

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>