### PR TITLE
Add LocalKeyVault configuration settings for the online key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   - id: flake8
     exclude: repository_service_tuf_worker/__init__.py|venv|.venv|setting.py|.git|.tox|dist|docs|/*lib/python*|/*egg|build|tools|alembic
 - repo: https://github.com/PyCQA/isort
-  rev: '5.10.1'
+  rev: '5.12.0'
   hooks:
   - id: isort
     args: [-l79, --profile, black, --check, --diff]

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -106,10 +106,13 @@ Available types:
   - Optional variables:
     - ``RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_NAME``
       - file name of the online key
+      - Default: `online.key`
     - ``RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_PASSWORD``
       - password used to load the online key
     - ``RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_TYPE``
-      - cryptographic type of the online key, example: `ed25519`, `rsa`
+      - cryptographic type of the online key, example: `ed25519`.
+      - Default: `ed25519`
+      - [Note: At the moment RSTUF Worker supports only `ed25519`
 
 
 #### (Optional) `DATA_DIR`

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -103,6 +103,13 @@ Available types:
 * LocalKeyVault (local file system)
   - Requires variable ``RSTUF_LOCAL_KEYVAULT_PATH``
     - Define the directory where the data will be saved, example: `keyvault`
+  - Optional variables:
+    - ``RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_NAME``
+      - file name of the online key
+    - ``RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_PASSWORD``
+      - password used to load the online key
+    - ``RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_TYPE``
+      - cryptographic type of the online key, example: `ed25519`, `rsa`
 
 
 #### (Optional) `DATA_DIR`

--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -33,7 +33,7 @@ class ServiceSettings:
 class IKeyVault(ABC):
     @classmethod
     @abstractmethod
-    def configure(cls, settings):
+    def configure(cls, settings) -> None:
         """
         Run actions to test, configure using the settings.
         """
@@ -41,7 +41,7 @@ class IKeyVault(ABC):
 
     @classmethod
     @abstractmethod
-    def settings(cls):
+    def settings(cls) -> List[ServiceSettings]:
         """
         Define all the ServiceSettings required in settings.
         """
@@ -63,7 +63,7 @@ class IKeyVault(ABC):
 class IStorage(ABC):
     @classmethod
     @abstractmethod
-    def configure(cls, settings: Any):
+    def configure(cls, settings: Any) -> None:
         """
         Run actions to test, configure using the settings.
         """

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from dynaconf import Dynaconf, loaders
 from dynaconf.utils.boxing import DynaBox
@@ -20,10 +20,27 @@ class KeyVaultError(Exception):
 class LocalKeyVault(IKeyVault):
     """Local KeyVault type"""
 
-    def __init__(self, path: str):
+    def __init__(
+        self,
+        path: str,
+        online_key_name: Optional[str] = "online.key",
+        online_key_pass: Optional[str] = None,
+        online_key_type: Optional[str] = "ed25519",
+    ):
+        """A configuration class for RSTUF Worker services.
+
+        Args:
+            path: directory of the key vault.
+            online_key_name: file name of the online key.
+            online_key_pass: password to load the online key.
+            online_key_type: cryptography type of the online key.
+        """
         self._path: str = path
         self._secrets_file: str = os.path.join(self._path, ".secrets.yaml")
-        self.keyvault = Dynaconf(
+        self._online_key_name: Optional[str] = online_key_name
+        self._online_key_password: Optional[str] = online_key_pass
+        self._online_key_type: Optional[str] = online_key_type
+        self._keyvault = Dynaconf(
             envvar_prefix="LOCALKEYVAULT",
             settings_files=[self._secrets_file],
         )
@@ -41,6 +58,21 @@ class LocalKeyVault(IKeyVault):
                 name="LOCAL_KEYVAULT_PATH",
                 argument="path",
                 required=True,
+            ),
+            ServiceSettings(
+                name="LOCAL_KEYVAULT_ONLINE_KEY_NAME",
+                argument="online_key_name",
+                required=False,
+            ),
+            ServiceSettings(
+                name="LOCAL_KEYVAULT_ONLINE_KEY_PASSWORD",
+                argument="online_key_pass",
+                required=False,
+            ),
+            ServiceSettings(
+                name="LOCAL_KEYVAULT_ONLINE_KEY_TYPE",
+                argument="online_key_type",
+                required=False,
             ),
         ]
 

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -27,7 +27,7 @@ class LocalKeyVault(IKeyVault):
         online_key_pass: Optional[str] = None,
         online_key_type: Optional[str] = "ed25519",
     ):
-        """A configuration class for RSTUF Worker services.
+        """Configuration class for RSTUF Worker LocalKeyVault service.
 
         Args:
             path: directory of the key vault.

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -46,12 +46,12 @@ class LocalKeyVault(IKeyVault):
         )
 
     @classmethod
-    def configure(cls, settings):
+    def configure(cls, settings) -> None:
         """Configure using the settings."""
         os.makedirs(settings.LOCAL_KEYVAULT_PATH, exist_ok=True)
 
     @classmethod
-    def settings(cls):
+    def settings(cls) -> List[ServiceSettings]:
         """Define the settings parameters."""
         return [
             ServiceSettings(
@@ -76,7 +76,7 @@ class LocalKeyVault(IKeyVault):
             ),
         ]
 
-    def get(self, rolename: str):
+    def get(self, rolename: str) -> Dict[str, Any]:
         """Get the Key from local KeyVault by role name."""
         keys_sslib_format: List[Dict[str, Any]] = []
         try:
@@ -90,7 +90,7 @@ class LocalKeyVault(IKeyVault):
 
         return keys_sslib_format
 
-    def put(self, rolename: str, keys: List[Dict[str, Any]]):
+    def put(self, rolename: str, keys: List[Dict[str, Any]]) -> None:
         """Save the Key in the local KeyVault."""
         key_vault_data: list = []
         for key in keys:

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,9 @@ setenv =
     RSTUF_LOCAL_STORAGE_BACKEND_PATH = ./data-test/s
     RSTUF_KEYVAULT_BACKEND = LocalKeyVault
     RSTUF_LOCAL_KEYVAULT_PATH = ./data-test/kv
+    RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_NAME = ./data-test/kv/online_key
+    RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_PASSWORD = password
+    RSTUF_LOCAL_KEYVAULT_ONLINE_KEY_TYPE = ed25519
     DATA_DIR = ./data-test
 
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Add configuration settings in LocalKeyVault for the online key that
will be used for "timestamp", "snapshot", "targets"  and "bin-n" roles.
That will allow us to load the online key instead of generating it
which is in line with what we want when we support more key vaults.

It's planned that if the user doesn't provide a path to the online key
as recommended we will generate an online key for him.

Additionally, add missing type annotations for the interfaces.

Close https://github.com/vmware/repository-service-tuf-worker/issues/169

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>