### PR TITLE
Add bandit to the pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,12 @@ repos:
   hooks:
   - id: black
     args: [-l79, --check, --diff, .]
+- repo: https://github.com/PyCQA/bandit
+  rev: '1.7.4'
+  hooks:
+  - id: bandit
+    args: ["-r", "tuf_repository_service_worker"]
+    exclude: tests.
 - repo: local
   hooks:
     - id: tox-requirements

--- a/Pipfile
+++ b/Pipfile
@@ -86,6 +86,8 @@ sphinxcontrib-qthelp = "==1.0.3"
 sphinxcontrib-serializinghtml = "==1.1.5"
 myst-parser = "*"
 pre-commit = "*"
+prospector = "*"
+bandit = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -86,7 +86,6 @@ sphinxcontrib-qthelp = "==1.0.3"
 sphinxcontrib-serializinghtml = "==1.1.5"
 myst-parser = "*"
 pre-commit = "*"
-prospector = "*"
 bandit = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6a35e169a9508f1860c275196c9bae17ac274d9ed3aa3b3d1a94e6574afac385"
+            "sha256": "103141af17592d4f64566340d6f6d3cba9afa7843fbc7122dc168222b6bbb908"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -735,6 +735,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==5.1.1"
         },
+        "astroid": {
+            "hashes": [
+                "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b",
+                "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"
+            ],
+            "markers": "python_full_version >= '3.7.2'",
+            "version": "==2.13.3"
+        },
         "async-timeout": {
             "hashes": [
                 "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15",
@@ -758,6 +766,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.11.0"
+        },
+        "bandit": {
+            "hashes": [
+                "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2",
+                "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"
+            ],
+            "index": "pypi",
+            "version": "==1.7.4"
         },
         "billiard": {
             "hashes": [
@@ -1113,6 +1129,14 @@
             "index": "pypi",
             "version": "==1.2.13"
         },
+        "dill": {
+            "hashes": [
+                "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
+                "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==0.3.6"
+        },
         "distlib": {
             "hashes": [
                 "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe",
@@ -1128,6 +1152,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.17.1"
+        },
+        "dodgy": {
+            "hashes": [
+                "sha256:28323cbfc9352139fdd3d316fa17f325cc0e9ac74438cbba51d70f9b48f86c3a",
+                "sha256:51f54c0fd886fa3854387f354b19f429d38c04f984f38bc572558b703c0542a6"
+            ],
+            "version": "==0.2.1"
         },
         "dynaconf": {
             "extras": [
@@ -1155,6 +1186,29 @@
             ],
             "index": "pypi",
             "version": "==5.0.4"
+        },
+        "flake8-polyfill": {
+            "hashes": [
+                "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9",
+                "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
+            ],
+            "version": "==1.0.2"
+        },
+        "gitdb": {
+            "hashes": [
+                "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a",
+                "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.10"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8",
+                "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.30"
         },
         "identify": {
             "hashes": [
@@ -1211,6 +1265,48 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.2.4"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382",
+                "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82",
+                "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9",
+                "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494",
+                "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46",
+                "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30",
+                "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63",
+                "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4",
+                "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae",
+                "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be",
+                "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701",
+                "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd",
+                "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006",
+                "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a",
+                "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586",
+                "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8",
+                "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821",
+                "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07",
+                "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b",
+                "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171",
+                "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b",
+                "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2",
+                "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7",
+                "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4",
+                "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8",
+                "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e",
+                "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f",
+                "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda",
+                "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4",
+                "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e",
+                "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671",
+                "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11",
+                "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455",
+                "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734",
+                "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb",
+                "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.9.0"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1355,11 +1451,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
-                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==23.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "pathspec": {
             "hashes": [
@@ -1368,6 +1464,21 @@
             ],
             "index": "pypi",
             "version": "==0.9.0"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b",
+                "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"
+            ],
+            "markers": "python_version >= '2.6'",
+            "version": "==5.11.1"
+        },
+        "pep8-naming": {
+            "hashes": [
+                "sha256:5d9f1056cb9427ce344e98d1a7f5665710e2f20f748438e308995852cfa24164",
+                "sha256:f3b4a5f9dd72b991bf7d8e2a341d2e1aa3a884a769b5aaac4f56825c1763bf3a"
+            ],
+            "version": "==0.10.0"
         },
         "platformdirs": {
             "hashes": [
@@ -1384,6 +1495,14 @@
             ],
             "index": "pypi",
             "version": "==1.0.0"
+        },
+        "poetry-semver": {
+            "hashes": [
+                "sha256:4e6349bd7231cc657f0e1930f7b204e87e33dfd63eef5cac869363969515083a",
+                "sha256:d809b612aa27b39bf2d0fc9d31b4f4809b0e972646c5f19cfa46c725b7638810"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.1.0"
         },
         "pre-commit": {
             "hashes": [
@@ -1409,6 +1528,14 @@
             "markers": "python_full_version >= '3.6.2'",
             "version": "==3.0.36"
         },
+        "prospector": {
+            "hashes": [
+                "sha256:4a9584544cf8d118574567a669b85456d036444597f0664185263e229055cdf6",
+                "sha256:60db5b6046a523248a1b32fb2daa8080d3f406da822ad95cff8cd9f153e04555"
+            ],
+            "index": "pypi",
+            "version": "==1.8.4"
+        },
         "py": {
             "hashes": [
                 "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
@@ -1432,6 +1559,14 @@
             ],
             "version": "==2.21"
         },
+        "pydocstyle": {
+            "hashes": [
+                "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019",
+                "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.3.0"
+        },
         "pyflakes": {
             "hashes": [
                 "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2",
@@ -1447,6 +1582,41 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.14.0"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e",
+                "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
+            ],
+            "markers": "python_full_version >= '3.7.2'",
+            "version": "==2.15.10"
+        },
+        "pylint-celery": {
+            "hashes": [
+                "sha256:41e32094e7408d15c044178ea828dd524beedbdbe6f83f712c5e35bde1de4beb"
+            ],
+            "version": "==0.3"
+        },
+        "pylint-django": {
+            "hashes": [
+                "sha256:0ac090d106c62fe33782a1d01bda1610b761bb1c9bf5035ced9d5f23a13d8591",
+                "sha256:56b12b6adf56d548412445bd35483034394a1a94901c3f8571980a13882299d5"
+            ],
+            "version": "==2.5.3"
+        },
+        "pylint-flask": {
+            "hashes": [
+                "sha256:f4d97de2216bf7bfce07c9c08b166e978fe9f2725de2a50a9845a97de7e31517"
+            ],
+            "version": "==0.6"
+        },
+        "pylint-plugin-utils": {
+            "hashes": [
+                "sha256:b3d43e85ab74c4f48bb46ae4ce771e39c3a20f8b3d56982ab17aa73b4f98d535",
+                "sha256:ce48bc0516ae9415dd5c752c940dfe601b18fe0f48aa249f2386adfa95a004dd"
+            ],
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==0.7"
         },
         "pynacl": {
             "hashes": [
@@ -1549,6 +1719,14 @@
             "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==2.28.2"
         },
+        "requirements-detector": {
+            "hashes": [
+                "sha256:9124b0fa5808660e2ae65a06049dfe248a7b7df73f8e9d48d0ad7f7c790690ad",
+                "sha256:d9fa8da14813500f6f94752c2bf4a6cf33d13e9f2140947f7df0149f1537437b"
+            ],
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.2'",
+            "version": "==1.0.3"
+        },
         "securesystemslib": {
             "hashes": [
                 "sha256:41c7b25c52dc0bafe774413b5738bbf4431f094e72a091e83d9921901972ae4c",
@@ -1556,6 +1734,13 @@
             ],
             "index": "pypi",
             "version": "==0.26.0"
+        },
+        "setoptconf-tmp": {
+            "hashes": [
+                "sha256:76035d5cd1593d38b9056ae12d460eca3aaa34ad05c315b69145e138ba80a745",
+                "sha256:e0480addd11347ba52f762f3c4d8afa3e10ad0affbc53e3ffddc0ca5f27d5778"
+            ],
+            "version": "==0.3.1"
         },
         "setuptools": {
             "hashes": [
@@ -1572,6 +1757,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "smmap": {
+            "hashes": [
+                "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94",
+                "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.0.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -1651,6 +1844,14 @@
             "index": "pypi",
             "version": "==1.1.5"
         },
+        "stevedore": {
+            "hashes": [
+                "sha256:7f8aeb6e3f90f96832c301bff21a7eb5eefbe894c88c506483d355565d88cc1a",
+                "sha256:aa6436565c069b2946fe4ebff07f5041e0c8bf18c7376dd29edf80cf7d524e4e"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.1.1"
+        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
@@ -1666,6 +1867,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.1"
+        },
+        "tomlkit": {
+            "hashes": [
+                "sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
+                "sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.11.6"
         },
         "tox": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "103141af17592d4f64566340d6f6d3cba9afa7843fbc7122dc168222b6bbb908"
+            "sha256": "988b4f257ea7472c1117a1fea215ae057606e18efdd5899b0271e2256bfca4c5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -735,14 +735,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==5.1.1"
         },
-        "astroid": {
-            "hashes": [
-                "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b",
-                "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"
-            ],
-            "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.13.3"
-        },
         "async-timeout": {
             "hashes": [
                 "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15",
@@ -1129,14 +1121,6 @@
             "index": "pypi",
             "version": "==1.2.13"
         },
-        "dill": {
-            "hashes": [
-                "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
-                "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==0.3.6"
-        },
         "distlib": {
             "hashes": [
                 "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe",
@@ -1152,13 +1136,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.17.1"
-        },
-        "dodgy": {
-            "hashes": [
-                "sha256:28323cbfc9352139fdd3d316fa17f325cc0e9ac74438cbba51d70f9b48f86c3a",
-                "sha256:51f54c0fd886fa3854387f354b19f429d38c04f984f38bc572558b703c0542a6"
-            ],
-            "version": "==0.2.1"
         },
         "dynaconf": {
             "extras": [
@@ -1186,13 +1163,6 @@
             ],
             "index": "pypi",
             "version": "==5.0.4"
-        },
-        "flake8-polyfill": {
-            "hashes": [
-                "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9",
-                "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
-            ],
-            "version": "==1.0.2"
         },
         "gitdb": {
             "hashes": [
@@ -1265,48 +1235,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.2.4"
-        },
-        "lazy-object-proxy": {
-            "hashes": [
-                "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382",
-                "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82",
-                "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9",
-                "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494",
-                "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46",
-                "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30",
-                "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63",
-                "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4",
-                "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae",
-                "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be",
-                "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701",
-                "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd",
-                "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006",
-                "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a",
-                "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586",
-                "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8",
-                "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821",
-                "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07",
-                "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b",
-                "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171",
-                "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b",
-                "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2",
-                "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7",
-                "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4",
-                "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8",
-                "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e",
-                "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f",
-                "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda",
-                "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4",
-                "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e",
-                "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671",
-                "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11",
-                "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455",
-                "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734",
-                "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb",
-                "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.9.0"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1451,11 +1379,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.0"
         },
         "pathspec": {
             "hashes": [
@@ -1473,13 +1401,6 @@
             "markers": "python_version >= '2.6'",
             "version": "==5.11.1"
         },
-        "pep8-naming": {
-            "hashes": [
-                "sha256:5d9f1056cb9427ce344e98d1a7f5665710e2f20f748438e308995852cfa24164",
-                "sha256:f3b4a5f9dd72b991bf7d8e2a341d2e1aa3a884a769b5aaac4f56825c1763bf3a"
-            ],
-            "version": "==0.10.0"
-        },
         "platformdirs": {
             "hashes": [
                 "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
@@ -1495,14 +1416,6 @@
             ],
             "index": "pypi",
             "version": "==1.0.0"
-        },
-        "poetry-semver": {
-            "hashes": [
-                "sha256:4e6349bd7231cc657f0e1930f7b204e87e33dfd63eef5cac869363969515083a",
-                "sha256:d809b612aa27b39bf2d0fc9d31b4f4809b0e972646c5f19cfa46c725b7638810"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.1.0"
         },
         "pre-commit": {
             "hashes": [
@@ -1528,14 +1441,6 @@
             "markers": "python_full_version >= '3.6.2'",
             "version": "==3.0.36"
         },
-        "prospector": {
-            "hashes": [
-                "sha256:4a9584544cf8d118574567a669b85456d036444597f0664185263e229055cdf6",
-                "sha256:60db5b6046a523248a1b32fb2daa8080d3f406da822ad95cff8cd9f153e04555"
-            ],
-            "index": "pypi",
-            "version": "==1.8.4"
-        },
         "py": {
             "hashes": [
                 "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
@@ -1559,14 +1464,6 @@
             ],
             "version": "==2.21"
         },
-        "pydocstyle": {
-            "hashes": [
-                "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019",
-                "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==6.3.0"
-        },
         "pyflakes": {
             "hashes": [
                 "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2",
@@ -1582,41 +1479,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.14.0"
-        },
-        "pylint": {
-            "hashes": [
-                "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e",
-                "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
-            ],
-            "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.15.10"
-        },
-        "pylint-celery": {
-            "hashes": [
-                "sha256:41e32094e7408d15c044178ea828dd524beedbdbe6f83f712c5e35bde1de4beb"
-            ],
-            "version": "==0.3"
-        },
-        "pylint-django": {
-            "hashes": [
-                "sha256:0ac090d106c62fe33782a1d01bda1610b761bb1c9bf5035ced9d5f23a13d8591",
-                "sha256:56b12b6adf56d548412445bd35483034394a1a94901c3f8571980a13882299d5"
-            ],
-            "version": "==2.5.3"
-        },
-        "pylint-flask": {
-            "hashes": [
-                "sha256:f4d97de2216bf7bfce07c9c08b166e978fe9f2725de2a50a9845a97de7e31517"
-            ],
-            "version": "==0.6"
-        },
-        "pylint-plugin-utils": {
-            "hashes": [
-                "sha256:b3d43e85ab74c4f48bb46ae4ce771e39c3a20f8b3d56982ab17aa73b4f98d535",
-                "sha256:ce48bc0516ae9415dd5c752c940dfe601b18fe0f48aa249f2386adfa95a004dd"
-            ],
-            "markers": "python_full_version >= '3.6.2'",
-            "version": "==0.7"
         },
         "pynacl": {
             "hashes": [
@@ -1719,14 +1581,6 @@
             "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==2.28.2"
         },
-        "requirements-detector": {
-            "hashes": [
-                "sha256:9124b0fa5808660e2ae65a06049dfe248a7b7df73f8e9d48d0ad7f7c790690ad",
-                "sha256:d9fa8da14813500f6f94752c2bf4a6cf33d13e9f2140947f7df0149f1537437b"
-            ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.2'",
-            "version": "==1.0.3"
-        },
         "securesystemslib": {
             "hashes": [
                 "sha256:41c7b25c52dc0bafe774413b5738bbf4431f094e72a091e83d9921901972ae4c",
@@ -1734,13 +1588,6 @@
             ],
             "index": "pypi",
             "version": "==0.26.0"
-        },
-        "setoptconf-tmp": {
-            "hashes": [
-                "sha256:76035d5cd1593d38b9056ae12d460eca3aaa34ad05c315b69145e138ba80a745",
-                "sha256:e0480addd11347ba52f762f3c4d8afa3e10ad0affbc53e3ffddc0ca5f27d5778"
-            ],
-            "version": "==0.3.1"
         },
         "setuptools": {
             "hashes": [
@@ -1867,14 +1714,6 @@
             ],
             "index": "pypi",
             "version": "==2.0.1"
-        },
-        "tomlkit": {
-            "hashes": [
-                "sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
-                "sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.11.6"
         },
         "tox": {
             "hashes": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -i https://pypi.org/simple
 alabaster==0.7.13 ; python_version >= '3.6'
 amqp==5.1.1 ; python_version >= '3.6'
-astroid==2.13.3 ; python_full_version >= '3.7.2'
 async-timeout==4.0.2 ; python_version >= '3.6'
 attrs==22.1.0
 babel==2.11.0 ; python_version >= '3.6'
@@ -21,14 +20,11 @@ configobj==5.0.8
 coverage==6.4.4
 cryptography==39.0.0
 deprecated==1.2.13
-dill==0.3.6 ; python_version < '3.11'
 distlib==0.3.5
 docutils==0.17.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-dodgy==0.2.1
 dynaconf[ini]==3.1.11
 filelock==3.8.0
 flake8==5.0.4
-flake8-polyfill==1.0.2
 gitdb==4.0.10 ; python_version >= '3.7'
 gitpython==3.1.30 ; python_version >= '3.7'
 identify==2.5.15 ; python_version >= '3.7'
@@ -38,7 +34,6 @@ iniconfig==1.1.1
 isort==5.10.1
 jinja2==3.1.2 ; python_version >= '3.7'
 kombu==5.2.4 ; python_version >= '3.7'
-lazy-object-proxy==1.9.0 ; python_version >= '3.7'
 markdown-it-py==2.1.0 ; python_version >= '3.7'
 markupsafe==2.1.2 ; python_version >= '3.7'
 mccabe==0.7.0
@@ -48,28 +43,19 @@ mypy==0.971
 mypy-extensions==0.4.3
 myst-parser==0.18.1
 nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==21.3 ; python_version >= '3.6'
+packaging==23.0 ; python_version >= '3.7'
 pathspec==0.9.0
 pbr==5.11.1 ; python_version >= '2.6'
-pep8-naming==0.10.0
 platformdirs==2.5.2
 pluggy==1.0.0
-poetry-semver==0.1.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pre-commit==3.0.0
 pretend==1.0.9
 prompt-toolkit==3.0.36 ; python_full_version >= '3.6.2'
-prospector==1.8.4
 py==1.11.0
 pycodestyle==2.9.1
 pycparser==2.21
-pydocstyle==6.3.0 ; python_version >= '3.6'
 pyflakes==2.5.0
 pygments==2.14.0 ; python_version >= '3.6'
-pylint==2.15.10 ; python_full_version >= '3.7.2'
-pylint-celery==0.3
-pylint-django==2.5.3
-pylint-flask==0.6
-pylint-plugin-utils==0.7 ; python_full_version >= '3.6.2'
 pynacl==1.5.0
 pyparsing==3.0.9
 pytest==7.1.2
@@ -77,9 +63,7 @@ pytz==2022.7.1
 pyyaml==6.0 ; python_version >= '3.6'
 redis==4.4.2
 requests==2.28.2 ; python_version >= '3.7' and python_version < '4'
-requirements-detector==1.0.3 ; python_version < '4.0' and python_full_version >= '3.6.2'
 securesystemslib==0.26.0
-setoptconf-tmp==0.3.1
 setuptools==66.1.1 ; python_version >= '3.7'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 smmap==5.0.0 ; python_version >= '3.6'
@@ -96,7 +80,6 @@ sphinxcontrib-serializinghtml==1.1.5
 stevedore==4.1.1 ; python_version >= '3.8'
 toml==0.10.2
 tomli==2.0.1
-tomlkit==0.11.6 ; python_version >= '3.6'
 tox==3.25.1
 tuf==2.0.0
 typing-extensions==4.4.0 ; python_version >= '3.7'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,11 @@
 -i https://pypi.org/simple
 alabaster==0.7.13 ; python_version >= '3.6'
 amqp==5.1.1 ; python_version >= '3.6'
+astroid==2.13.3 ; python_full_version >= '3.7.2'
 async-timeout==4.0.2 ; python_version >= '3.6'
 attrs==22.1.0
 babel==2.11.0 ; python_version >= '3.6'
+bandit==1.7.4
 billiard==3.6.4.0
 black==22.6.0
 celery==5.2.7
@@ -19,11 +21,16 @@ configobj==5.0.8
 coverage==6.4.4
 cryptography==39.0.0
 deprecated==1.2.13
+dill==0.3.6 ; python_version < '3.11'
 distlib==0.3.5
 docutils==0.17.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+dodgy==0.2.1
 dynaconf[ini]==3.1.11
 filelock==3.8.0
 flake8==5.0.4
+flake8-polyfill==1.0.2
+gitdb==4.0.10 ; python_version >= '3.7'
+gitpython==3.1.30 ; python_version >= '3.7'
 identify==2.5.15 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
 imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
@@ -31,6 +38,7 @@ iniconfig==1.1.1
 isort==5.10.1
 jinja2==3.1.2 ; python_version >= '3.7'
 kombu==5.2.4 ; python_version >= '3.7'
+lazy-object-proxy==1.9.0 ; python_version >= '3.7'
 markdown-it-py==2.1.0 ; python_version >= '3.7'
 markupsafe==2.1.2 ; python_version >= '3.7'
 mccabe==0.7.0
@@ -40,18 +48,28 @@ mypy==0.971
 mypy-extensions==0.4.3
 myst-parser==0.18.1
 nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==23.0 ; python_version >= '3.7'
+packaging==21.3 ; python_version >= '3.6'
 pathspec==0.9.0
+pbr==5.11.1 ; python_version >= '2.6'
+pep8-naming==0.10.0
 platformdirs==2.5.2
 pluggy==1.0.0
+poetry-semver==0.1.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pre-commit==3.0.0
 pretend==1.0.9
 prompt-toolkit==3.0.36 ; python_full_version >= '3.6.2'
+prospector==1.8.4
 py==1.11.0
 pycodestyle==2.9.1
 pycparser==2.21
+pydocstyle==6.3.0 ; python_version >= '3.6'
 pyflakes==2.5.0
 pygments==2.14.0 ; python_version >= '3.6'
+pylint==2.15.10 ; python_full_version >= '3.7.2'
+pylint-celery==0.3
+pylint-django==2.5.3
+pylint-flask==0.6
+pylint-plugin-utils==0.7 ; python_full_version >= '3.6.2'
 pynacl==1.5.0
 pyparsing==3.0.9
 pytest==7.1.2
@@ -59,9 +77,12 @@ pytz==2022.7.1
 pyyaml==6.0 ; python_version >= '3.6'
 redis==4.4.2
 requests==2.28.2 ; python_version >= '3.7' and python_version < '4'
+requirements-detector==1.0.3 ; python_version < '4.0' and python_full_version >= '3.6.2'
 securesystemslib==0.26.0
+setoptconf-tmp==0.3.1
 setuptools==66.1.1 ; python_version >= '3.7'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+smmap==5.0.0 ; python_version >= '3.6'
 snowballstemmer==2.2.0
 sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
@@ -72,8 +93,10 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.24
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
+stevedore==4.1.1 ; python_version >= '3.8'
 toml==0.10.2
 tomli==2.0.1
+tomlkit==0.11.6 ; python_version >= '3.6'
 tox==3.25.1
 tuf==2.0.0
 typing-extensions==4.4.0 ; python_version >= '3.7'

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
     pre-commit run flake8 --all-files --show-diff-on-failure
     pre-commit run isort --all-files --show-diff-on-failure
     pre-commit run black --all-files --show-diff-on-failure
+    pre-commit run bandit --all-files --show-diff-on-failure
 
 [testenv:test]
 commands =


### PR DESCRIPTION
To achieve the OpenSSF Best Practices badge, we need to implement the static code analysis tool.

This commit adds the `bandit` to the RSTUF Worker.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>