### PR TITLE
fix: Local storage service write permission

### DIFF
--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -16,7 +16,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from tuf.api.metadata import Metadata, T
 
@@ -89,7 +89,6 @@ class IStorage(ABC):
         self,
         file_data: bytes,
         filename: str,
-        restrict: Optional[bool] = True,
     ) -> None:
         """
         Stores file bytes within a file with a specific filename.

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -4,10 +4,9 @@
 
 import glob
 import os
-import stat
 from contextlib import contextmanager
 from io import BufferedReader
-from typing import List, Optional
+from typing import List
 
 from securesystemslib.exceptions import StorageError  # noqa
 
@@ -73,7 +72,6 @@ class LocalStorage(IStorage):
         self,
         file_data: bytes,
         filename: str,
-        restrict: Optional[bool] = True,
     ) -> None:
         """
         Writes passed file object to configured TUF repo path using the passed
@@ -81,22 +79,8 @@ class LocalStorage(IStorage):
         """
         filename = os.path.join(self._path, filename)
 
-        if restrict:
-            # On UNIX-based systems restricted files are created with read and
-            # write permissions for the user only (octal value 0o600).
-            fd = os.open(
-                filename, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR
-            )
-        else:
-            # Non-restricted files use the default 'mode' argument of os.open()
-            # granting read, write, and execute for all users (mode 0o777).
-            # NOTE: mode may be modified by the user's file mode creation mask
-            # (umask) or on Windows limited to the smaller set of OS supported
-            # permisssions.
-            fd = os.open(filename, os.O_WRONLY | os.O_CREAT)
-
         try:
-            with os.fdopen(fd, "wb") as destination_file:
+            with open(filename, "wb") as destination_file:
                 destination_file.write(file_data)
                 destination_file.flush()
                 os.fsync(destination_file.fileno())

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os
-
 import pretend
 import pytest
 
@@ -172,18 +170,8 @@ class TestLocalStorageService:
         ]
         assert local.glob.glob.calls == [pretend.call("/path/2.root.json")]
 
-    def _put_setup(self, fake_destination_file, restrict=True):
-        """Setup helper for all required functions in LocalStorage.put()"""
-
-        class FakeDestinationFile:
-            def __init__(self):
-                pass
-
-            def __enter__(self):
-                return fake_destination_file
-
-            def __exit__(self, type, value, traceback):
-                pass
+    def test_put(self, monkeypatch):
+        service = local.LocalStorage("/path")
 
         local.os = pretend.stub(
             path=pretend.stub(
@@ -192,65 +180,39 @@ class TestLocalStorageService:
                 )
             ),
             fsync=pretend.call_recorder(lambda *a: None),
-            O_WRONLY=0,
-            O_CREAT=0,
-            open=pretend.call_recorder(lambda *a: 0),
-            fdopen=pretend.call_recorder(lambda *a: FakeDestinationFile()),
         )
 
-        if restrict:
-            local.stat = pretend.stub(S_IRUSR=0, S_IWUSR=0)
-
-    def test_put(self):
-        service = local.LocalStorage("/path")
+        fake_file_data = b"fake_byte_data"
 
         fake_destination_file = pretend.stub(
-            write=pretend.call_recorder(lambda *a: None),
+            write=pretend.call_recorder(lambda *a: "bytes_data"),
             flush=pretend.call_recorder(lambda: None),
             fileno=pretend.call_recorder(lambda: "fileno"),
         )
 
-        fake_bytes = b"data"
+        class FakeDestinationFile:
+            def __init__(self, file, mode):
+                return None
 
-        self._put_setup(fake_destination_file)
-        result = service.put(fake_bytes, "3.bin-e.json")
+            def __enter__(self):
+                return fake_destination_file
 
-        assert result is None
-        assert local.os.path.join.calls == [
-            pretend.call(service._path, "3.bin-e.json"),
-        ]
-        expected_file_path = os.path.join(service._path, "3.bin-e.json")
-        assert local.os.open.calls == [pretend.call(expected_file_path, 0, 0)]
-        assert local.os.fdopen.calls == [pretend.call(0, "wb")]
-        assert fake_destination_file.write.calls == [pretend.call(fake_bytes)]
-        assert fake_destination_file.flush.calls == [pretend.call()]
-        assert fake_destination_file.fileno.calls == [pretend.call()]
-        assert local.os.fsync.calls == [pretend.call("fileno")]
+            def __exit__(self, type, value, traceback):
+                pass
 
-    def test_put_without_restrict(self):
-        service = local.LocalStorage("/path")
+        monkeypatch.setitem(local.__builtins__, "open", FakeDestinationFile)
 
-        fake_destination_file = pretend.stub(
-            write=pretend.call_recorder(lambda *a: None),
-            flush=pretend.call_recorder(lambda: None),
-            fileno=pretend.call_recorder(lambda: "fileno"),
-        )
-
-        fake_bytes = b"data"
-
-        self._put_setup(fake_destination_file, False)
-        result = service.put(fake_bytes, "3.bin-e.json", False)
+        result = service.put(fake_file_data, b"3.bin-e.json")
 
         assert result is None
         assert local.os.path.join.calls == [
-            pretend.call(service._path, "3.bin-e.json"),
+            pretend.call(service._path, b"3.bin-e.json"),
         ]
-        expected_file_path = os.path.join(service._path, "3.bin-e.json")
-        assert local.os.open.calls == [pretend.call(expected_file_path, 0)]
-        assert local.os.fdopen.calls == [pretend.call(0, "wb")]
-        assert fake_destination_file.write.calls == [pretend.call(fake_bytes)]
+        assert fake_destination_file.write.calls == [
+            pretend.call(fake_file_data)
+        ]
         assert fake_destination_file.flush.calls == [pretend.call()]
-        assert fake_destination_file.fileno.calls == [pretend.call()]
+        assert fake_destination_file.flush.calls == [pretend.call()]
         assert local.os.fsync.calls == [pretend.call("fileno")]
 
     def test_put_OSError(self):
@@ -263,17 +225,14 @@ class TestLocalStorageService:
                 )
             ),
             open=pretend.raiser(PermissionError("don't want this message")),
-            O_WRONLY=0,
-            O_CREAT=0,
         )
 
-        local.stat = pretend.stub(S_IRUSR=0, S_IWUSR=0)
         fake_bytes = b"data"
 
-        with pytest.raises(OSError) as err:
+        with pytest.raises(local.StorageError) as err:
             service.put(fake_bytes, "3.bin-e.json")
 
-        assert "don't want this message" in str(err)
+        assert "Can't write role file '/path/3.bin-e.json'" in str(err)
         assert local.os.path.join.calls == [
             pretend.call(service._path, "3.bin-e.json"),
         ]

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -212,7 +212,7 @@ class TestLocalStorageService:
             pretend.call(fake_file_data)
         ]
         assert fake_destination_file.flush.calls == [pretend.call()]
-        assert fake_destination_file.flush.calls == [pretend.call()]
+        assert fake_destination_file.fileno.calls == [pretend.call()]
         assert local.os.fsync.calls == [pretend.call("fileno")]
 
     def test_put_OSError(self):


### PR DESCRIPTION
Fixes the Local storage service write permission implementation.

The Local Storage files don't require restricted permission (0o600) as the local storage writes publicly readable metadata files.

Only Private keys require security restriction permission.

Closes #183

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>