### PR TITLE
chore: improve performance updating Targets in DB

### DIFF
--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -119,19 +119,20 @@ def update(
     return target
 
 
-def update_to_published(
-    db: Session, target: models.RSTUFTargets
-) -> models.RSTUFTargets:
+def update_to_published(db: Session, paths: List[str]) -> None:
     """
     Update Target to `published` to `True`.
     """
-    target.published = True
-    target.last_update = datetime.now()
-    db.add(target)
-    db.commit()
-    db.refresh(target)
 
-    return target
+    db.query(models.RSTUFTargets).filter(
+        models.RSTUFTargets.path.in_(paths)
+    ).update(
+        {
+            models.RSTUFTargets.published: True,
+            models.RSTUFTargets.last_update: datetime.now(),
+        }
+    )
+    db.commit()
 
 
 def update_action_remove(

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -263,7 +263,7 @@ class MetadataRepository:
     def _update_timestamp(
         self,
         snapshot_version: int,
-        db_targets: Optional[List[targets_models.RSTUFTargets]] = None,
+        db_targets: Optional[List[str]] = None,
     ) -> Metadata[Timestamp]:
         """
         Loads 'timestamp', updates meta info about passed 'snapshot'
@@ -284,8 +284,7 @@ class MetadataRepository:
 
         # TODO review if here is the best place to change the status in DB
         if db_targets:
-            for db_target in db_targets:
-                targets_crud.update_to_published(self._db, db_target)
+            targets_crud.update_to_published(self._db, db_targets)
 
         return timestamp
 
@@ -442,7 +441,7 @@ class MetadataRepository:
             # initialize the new snapshot targets meta and published targets
             # from DB SQL
             new_snapshot_meta: List[Tuple(str, int)] = []
-            db_published_targets: List[targets_models.RSTUFTargets] = []
+            db_published_targets: List[str] = []
             for _, rolename in unpublished_roles:
                 # get the unpublished targets for the delegated, it will be use
                 # to update the database when Snapshot and Timestamp is
@@ -451,7 +450,7 @@ class MetadataRepository:
                     db=self._db, rolename=rolename
                 )
                 logging.debug(f"{rolename}: New targets #: {len(db_targets)}")
-                db_published_targets += db_targets
+                db_published_targets += [target.path for target in db_targets]
 
                 # load the delegated targets role, clean the targets and add
                 # a new meta from the SQL DB.

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -233,10 +233,10 @@ class TestMetadataRepository:
             "update_to_published",
             mocked_crud_update_to_publish,
         )
-        faked_db_target = pretend.stub()
+        faked_db_targets = pretend.stub(path="path/file1")
 
         result = test_repo._update_timestamp(
-            snapshot_version, [faked_db_target]
+            snapshot_version, [faked_db_targets]
         )
 
         assert result == mocked_timestamp
@@ -257,7 +257,7 @@ class TestMetadataRepository:
             pretend.call(mocked_timestamp, repository.Roles.TIMESTAMP.value)
         ]
         assert mocked_crud_update_to_publish.calls == [
-            pretend.call(test_repo._db, faked_db_target)
+            pretend.call(test_repo._db, [faked_db_targets])
         ]
 
     def test__update_snapshot(self):
@@ -451,9 +451,11 @@ class TestMetadataRepository:
             "read_unpublished_rolenames",
             fake_crud_read_unpublished_rolenames,
         )
-        fake_db_targets = pretend.stub()
         fake_crud_read_unpublished_by_rolename = pretend.call_recorder(
-            lambda **kw: [fake_db_targets, fake_db_targets]
+            lambda **kw: [
+                pretend.stub(path="path/file1"),
+                pretend.stub(path="path/file2"),
+            ]
         )
         monkeypatch.setattr(
             repository.targets_crud,
@@ -530,10 +532,10 @@ class TestMetadataRepository:
             pretend.call(
                 "fake_md_snapshot",
                 [
-                    fake_db_targets,
-                    fake_db_targets,
-                    fake_db_targets,
-                    fake_db_targets,
+                    "path/file1",
+                    "path/file2",
+                    "path/file1",
+                    "path/file2",
                 ],
             )
         ]


### PR DESCRIPTION
This improves the performance of updating Targets in the SQL DB.

Previously, we used to update the targets one by one in the DB and this commit made it in bulk.

In publishing new targets, we used to persist in the hashed bins with new targets to the backend storage, update the snapshot, and update the timestamp followed by the targets one by one in the SQL DB.

The last step was improved doing the update of all published targets at once.

Closes #176

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>