### PR TITLE
Skip refresh settings on subtasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,14 +75,14 @@ def repository_service_tuf_worker(
     refresh_settings: Optional[bool] = True,
 ):
     """
-    Accepts Celery tasks with an action to be executed.
+    Repository Service for TUF Metadata Worker main Celery consumer.
 
     Args:
         action: which action to be executed by the task.
         payload: data that will be given to the action.
         refresh_settings: whether to refresh repository settings.
     """
-    if refresh_settings:
+    if refresh_settings is True:
         repository.refresh_settings(worker_settings)
 
     repository_action = getattr(repository, action)

--- a/app.py
+++ b/app.py
@@ -75,7 +75,12 @@ def repository_service_tuf_worker(
     refresh_settings: Optional[bool] = True,
 ):
     """
-    Repository Service for TUF Metadata Worker
+    Accepts Celery tasks with an action to be executed.
+
+    Args:
+        action: which action to be executed by the task.
+        payload: data that will be given to the action.
+        refresh_settings: whether to refresh repository settings.
     """
     if refresh_settings:
         repository.refresh_settings(worker_settings)

--- a/app.py
+++ b/app.py
@@ -69,12 +69,17 @@ app = Celery(
 
 @app.task(serializer="json", bind=True)
 def repository_service_tuf_worker(
-    self, action: str, payload: Optional[Dict[str, Any]] = None
+    self,
+    action: str,
+    payload: Optional[Dict[str, Any]] = None,
+    refresh_settings: Optional[bool] = True,
 ):
     """
     Repository Service for TUF Metadata Worker
     """
-    repository.refresh_settings(worker_settings)
+    if refresh_settings:
+        repository.refresh_settings(worker_settings)
+
     repository_action = getattr(repository, action)
     if payload is None:
         result = repository_action()

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -377,6 +377,7 @@ class MetadataRepository:
             kwargs={
                 "action": "publish_targets",
                 "payload": None,
+                "refresh_settings": False,
             },
             task_id=f"publish_targets-{task_id}",
             queue="rstuf_internals",

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -47,12 +47,29 @@ class TestApp:
             test_action=pretend.call_recorder(lambda *a, **kw: True),
         )
 
-        result = app.repository_service_tuf_worker(
-            "test_action",
-        )
+        result = app.repository_service_tuf_worker("test_action")
+
         assert result is True
         assert app.repository.test_action.calls == [
             pretend.call(),
+        ]
+
+    def test_repository_service_tuf_worker_refresh_settings_false(self):
+        import app
+
+        app.repository = pretend.stub(
+            test_action=pretend.call_recorder(lambda *a, **kw: True),
+        )
+
+        result = app.repository_service_tuf_worker(
+            "test_action", payload={"k": "v"}, refresh_settings=False
+        )
+        assert result is True
+        assert app.repository.test_action.calls == [
+            pretend.call(
+                {"k": "v", "task_id": None},
+                update_state=app.repository_service_tuf_worker.update_state,
+            ),
         ]
 
     def test__publish_signals(self):


### PR DESCRIPTION
There is no point in refreshing the repository settings when we launch
a subtask from a main task that has already updated the repository
settings.
That's what happens when we launch a new "publish_targets" from the
"repository._send_publish_targets_task()" function.

By default this optional argument "refresh_settings" is false to
make sure we don't break any of the current components launching a
worker task.

Close https://github.com/vmware/repository-service-tuf-worker/issues/178

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>
