### PR TITLE
fix: remove wrong entry in the file

### DIFF
--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -2,17 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass


### PR DESCRIPTION
RSTUF is MIT licensed.
Removed some wrong entry in the file.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>