### PR TITLE
Monitor publish tasks sub task and remove automatic job publishing targets

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,18 +150,6 @@ app.conf.beat_schedule = {
             "acks_late": True,
         },
     },
-    "publish_targets": {
-        "task": "app.repository_service_tuf_worker",
-        "schedule": schedules.crontab(minute="*/1"),
-        "kwargs": {
-            "action": "publish_targets",
-        },
-        "options": {
-            "task_id": "publish_targets",
-            "queue": "rstuf_internals",
-            "acks_late": True,
-        },
-    },
 }
 
 repository = MetadataRepository.create_service()


### PR DESCRIPTION
When adding/removing targets, it triggers a new job to publish the
targets.

This subtask could fail for some reason, and we don't monitor it.

This commit adds the monitoring for this task and will give details
to the user once it fails the parent task (add/remove targets).

Closes #190

The monitoring is done in the `_update_task` as part of checks.

As discussed in issue https://github.com/vmware/repository-service-tuf-worker/issues/175, we removed the automatic job that
publishes targets every minute.

The publish targets are done to persist in the RSTUF Worker backend
storage of the updated metadata with the new targets.

1. We will give full control over the failure to add/remove targets
to the user. They can decide to reprocess the entire flow (add/remove
targets), or they can trigger publish targets.
2. The automatic job publishes targets creates confusion when and who
publishes the targets if the automatic job wins in the race condition
with add/remove targets.
3. For the feature load/import data it can slow down the process and
it would require an way to disable the automatic jobs during this
process, adding a lot of confusion.