### PR TITLE
Removes The Apache License

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -2,19 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
 import enum
 import importlib
 import logging


### PR DESCRIPTION
This deletes text referring to Apache License in repository.py.

Signed-off-by: Enyinna Ochulor <eochulor@vmware.com>