### PR TITLE
Add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.tox/
+venv/
+.idea/
+.vscode/
+.env/


### PR DESCRIPTION
Add dockerignore file to exclude big size directories when sending build context to the Docker deamon. These dirs are not needed during the docker image build process, and they slow down the start of the build process.