### PR TITLE
Flexible maintainer CD Workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,6 @@ jobs:
     needs: publish-container-image
     runs-on: ubuntu-latest
     outputs:
-      worker_version: ${{ steps.worker_version.outputs.VERSION }}
       api_version: ${{ steps.api_version.outputs.VERSION }}
       cli_version: ${{ steps.cli_version.outputs.VERSION }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,39 +1,60 @@
 name: CD
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - v*
+  workflow_dispatch:
+    inputs:
+      api_version:
+        description: "API Version"
+        default: "latest"
+        type: string
+        required: False
+      cli_version:
+        description: "CLI Version"
+        default: "latest"
+        type: string
+        required: False
+
 
 jobs:
-  functional-latest:
-    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
+  publish-container-image:
+    uses: ./.github/workflows/publish_container.yml
     with:
-      worker_version: dev
-      api_version: latest
-      cli_version: latest
+      image_version: ${{ github.sha }}
 
-  release:
-    needs: functional-latest
+  set-component-versions:
+    needs: publish-container-image
     runs-on: ubuntu-latest
+    outputs:
+      worker_version: ${{ steps.worker_version.outputs.VERSION }}
+      api_version: ${{ steps.api_version.outputs.VERSION }}
+      cli_version: ${{ steps.cli_version.outputs.VERSION }}
 
     steps:
-    - name: Checkout release tag
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      with:
-        ref: ${{ github.event.workflow_run.head_branch }}
+      - id: api_version
+        name: dynamic input worker version
+        run: |
+          if [[ "${{ inputs.api_version }}" == "" ]]; then echo "VERSION=latest" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.api_version }}" >> $GITHUB_OUTPUT;fi
 
-    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
-      with:
-        python-version: '3.10'
+      - id: cli_version
+        name: dynamic input cli version
+        run: |
+          if [[ "${{ inputs.cli_version }}" == "" ]]; then echo "VERSION=latest" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.cli_version }}" >> $GITHUB_OUTPUT;fi
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+  functional-tests:
+    needs: set-component-versions
+    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
+    with:
+      worker_version: ${{ github.sha }}
+      api_version: ${{ needs.set-component-versions.outputs.api_version }}
+      cli_version: ${{ needs.set-component-versions.outputs.cli_version }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
-
+  release:
+    runs-on: ubuntu-latest
+    needs: functional-tests
+    steps:
     - name: Login to GitHub Container Registry
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:
@@ -41,27 +62,13 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    # Cannot use output type docker local and push. Build and export and caches
-    - name: Build and export
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-      with:
-        context: .
-        tags: |
-            ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
-            ghcr.io/vmware/repository-service-tuf-worker:latest
-        outputs: type=docker,dest=/tmp/repository-service-tuf-worker_${{ github.ref_name }}.tar
-        cache-to: type=local,dest=/tmp/rstuf_worker_cache
-
-    # Build and push using the local cache from above step
-    - name: Build and push (using cache)
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-      with:
-        context: .
-        push: true
-        tags: |
-            ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
-            ghcr.io/vmware/repository-service-tuf-worker:latest
-        cache-from: type=local,src=/tmp/rstuf_worker_cache
+    - name: Add final tags
+      run: |
+        docker pull ghcr.io/vmware/repository-service-tuf-worker:${{ github.sha }}
+        docker tag ghcr.io/vmware/repository-service-tuf-worker:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
+        docker push ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
+        docker tag ghcr.io/vmware/repository-service-tuf-worker:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-worker:latest
+        docker push ghcr.io/vmware/repository-service-tuf-worker:latest
 
     - name: Publish GitHub Release
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,0 +1,56 @@
+name: Publish Container Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_version:
+        description: "Image version"
+        default: "dev"
+        type: string
+        required: False
+  workflow_call:
+    inputs:
+      image_version:
+        description: "Image version"
+        default: "dev"
+        type: string
+        required: False
+
+jobs:
+  publish_container_image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout release tag
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.image_version }}
+
+    - name: Set default Python version
+      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      with:
+        python-version: '3.10'
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/vmware/repository-service-tuf-worker:${{ inputs.image_version }}
+        build-args: |
+          RELEASE_VERSION=${{ inputs.image_version }}


### PR DESCRIPTION
This PR introduces a change in the `cd.yml` and adds the `publish_container.yml  Workflow.

We release our components versions using the tags `v*` The process of release has two steps:

1) Run the functional tests (FT) using the component to be released `v*` tag (from `main` branch) against the latest releases of the components.

2) If the (FT) finishes successfully, the `cd.yml` releases the new Docker Image GitHub Registry and adds it to our Releases page in Github. (Python package in case of the CLI).

If step 1 fails, the release breaks the compatibility with the current release.

The problem we are solving is how to release a new version when it breaks the compatibility.

This PR adds the workflow dispatch option for releases. The maintainers can now go to the Actions > CD > Run Workflow, hoose the `v*` tag release, and specify the version of the components it is compatible with, including dev (main branch) to run the FT tests.

Using the Workflow dispatcher process, the Maintainers should bump to a version that shows it is breaking compatibility and make it clear on the release page.

We have a (release process)[https://repository-service-tuf.readthedocs.io/en/latest/devel/release.html#release-process] and we are not changing it, only adding the Workflow that allows those actions.