### PR TITLE
Update Metadata During Bootstrap

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -421,6 +421,8 @@ class MetadataRepository:
             self._persist(metadata, role_name)
             logging.debug(f"{role_name}.json saved")
 
+        self.bump_online_roles()
+
         result = ResultDetails(
             status="Task finished.",
             details={

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -426,6 +426,7 @@ class TestMetadataRepository:
         )
         repository.JSONSerializer = pretend.call_recorder(lambda: None)
         test_repo._storage_backend = pretend.stub()
+        test_repo.bump_online_roles = pretend.call_recorder(lambda *a: None)
 
         fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
         fake_datetime = pretend.stub(
@@ -459,6 +460,7 @@ class TestMetadataRepository:
             pretend.call("fake_metadata", "1.root"),
             pretend.call("fake_metadata", "1.snapshot"),
         ]
+        assert test_repo.bump_online_roles.calls == [pretend.call()]
 
     def test_bootstrap_missing_settings(self):
         test_repo = repository.MetadataRepository.create_service()


### PR DESCRIPTION
This calls bump_online_role to update snapshot, timestamp, target, and bins during a bootstrap operation. This way, the updates don't have to wait for the automatic check to update those values.

Closes #26