### PR TITLE
Make tests repository and app tests independent

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional
 import redis
 from celery import Celery, schedules, signals
 
-from repository_service_tuf_worker import worker_settings
+from repository_service_tuf_worker import get_worker_settings
 from repository_service_tuf_worker.repository import MetadataRepository
 
 logging.basicConfig(
@@ -25,6 +25,9 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
     datefmt="%H:%M:%S",
 )
+
+
+worker_settings = get_worker_settings()
 
 
 class status(Enum):

--- a/repository_service_tuf_worker/__init__.py
+++ b/repository_service_tuf_worker/__init__.py
@@ -8,21 +8,25 @@ from dynaconf import Dynaconf
 
 DATA_DIR = os.getenv("DATA_DIR", "/data")
 os.makedirs(DATA_DIR, exist_ok=True)
-SETTINGS_FILE = os.path.join(DATA_DIR, "settings.ini")
-
-worker_settings = Dynaconf(
-    settings_files=[SETTINGS_FILE],
-    envvar_prefix="RSTUF",
-)
 
 
-SETTINGS_REPOSITORY_FILE = os.path.join(DATA_DIR, "task_settings.ini")
-repository_settings = Dynaconf(
-    redis_enabled=True,
-    redis={
-        "host": worker_settings.REDIS_SERVER.split("redis://")[1],
-        "port": worker_settings.get("REDIS_SERVER_PORT", 6379),
-        "db": worker_settings.get("REDIS_SERVER_DB_REPO_SETTINGS", 1),
-        "decode_responses": True,
-    },
-)
+def get_worker_settings() -> Dynaconf:
+    SETTINGS_FILE = os.path.join(DATA_DIR, "settings.ini")
+    return Dynaconf(
+        settings_files=[SETTINGS_FILE],
+        envvar_prefix="RSTUF",
+    )
+
+
+def get_repository_settings() -> Dynaconf:
+    worker_settings = get_worker_settings()
+
+    return Dynaconf(
+        redis_enabled=True,
+        redis={
+            "host": worker_settings.REDIS_SERVER.split("redis://")[1],
+            "port": worker_settings.get("REDIS_SERVER_PORT", 6379),
+            "db": worker_settings.get("REDIS_SERVER_DB_REPO_SETTINGS", 1),
+            "decode_responses": True,
+        },
+    )

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -42,9 +42,9 @@ from tuf.api.serialization.json import JSONSerializer
 # the 'service import is used to retrieve sublcasses (Implemented Services)
 from repository_service_tuf_worker import (  # noqa
     Dynaconf,
-    repository_settings,
+    get_repository_settings,
+    get_worker_settings,
     services,
-    worker_settings,
 )
 from repository_service_tuf_worker.interfaces import IKeyVault, IStorage
 from repository_service_tuf_worker.models import (
@@ -86,12 +86,14 @@ class MetadataRepository:
     """
 
     def __init__(self):
-        self._worker_settings = worker_settings
-        self._settings = repository_settings
+        self._worker_settings = get_worker_settings()
+        self._settings = get_repository_settings()
         self._storage_backend = self.refresh_settings().STORAGE
         self._key_storage_backend = self.refresh_settings().KEYVAULT
         self._db = self.refresh_settings().SQL
-        self._redis = redis.StrictRedis.from_url(worker_settings.REDIS_SERVER)
+        self._redis = redis.StrictRedis.from_url(
+            self._worker_settings.REDIS_SERVER
+        )
         self._hours_before_expire: int = self._settings.get_fresh(
             "HOURS_BEFORE_EXPIRE", 1
         )

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -33,7 +33,6 @@ class TestTargetsCrud:
         assert mocked_db.refresh.calls == [pretend.call("fake_db_target")]
 
     def test_read_unpublished_rolenames(self):
-
         crud.models.RSTUFTargets = pretend.stub(
             published=False, rolename="all-bins"
         )
@@ -66,7 +65,6 @@ class TestTargetsCrud:
         assert mocked_all.all.calls == [pretend.call()]
 
     def test_read_by_path(self):
-
         crud.models.RSTUFTargets = pretend.stub(path="file1.tar.gz")
         mocked_first = pretend.stub(
             first=pretend.call_recorder(lambda: crud.models.RSTUFTargets)
@@ -88,7 +86,6 @@ class TestTargetsCrud:
         assert mocked_first.first.calls == [pretend.call()]
 
     def test_read_by_rolename(self):
-
         crud.models.RSTUFTargets = pretend.stub(rolename="bin-0")
         mocked_all = pretend.stub(
             all=pretend.call_recorder(lambda: [crud.models.RSTUFTargets])
@@ -110,7 +107,6 @@ class TestTargetsCrud:
         assert mocked_all.all.calls == [pretend.call()]
 
     def test_read_unpublished_by_rolename(self):
-
         crud.models.RSTUFTargets = pretend.stub(
             published=False, rolename="bin-0"
         )
@@ -134,7 +130,6 @@ class TestTargetsCrud:
         assert mocked_all.all.calls == [pretend.call()]
 
     def test_read_all_add_by_rolename(self):
-
         crud.models.RSTUFTargets = pretend.stub(
             path="file2.tar.gz",
             info={"info": {"k": "v"}},
@@ -171,7 +166,6 @@ class TestTargetsCrud:
         assert mocked_all.all.calls == [pretend.call()]
 
     def test_update(self, monkeypatch):
-
         mocked_db = pretend.stub(
             add=pretend.call_recorder(lambda *a: None),
             commit=pretend.call_recorder(lambda: None),
@@ -211,7 +205,6 @@ class TestTargetsCrud:
         assert fake_datetime.now.calls == [pretend.call()]
 
     def test_update_to_published(self, monkeypatch):
-
         mocked_db = pretend.stub(
             add=pretend.call_recorder(lambda *a: None),
             commit=pretend.call_recorder(lambda: None),
@@ -248,7 +241,6 @@ class TestTargetsCrud:
         assert fake_datetime.now.calls == [pretend.call()]
 
     def test_update_action_remove(self, monkeypatch):
-
         mocked_db = pretend.stub(
             add=pretend.call_recorder(lambda *a: None),
             commit=pretend.call_recorder(lambda: None),

--- a/tests/unit/tuf_repository_service_worker/test__init__.py
+++ b/tests/unit/tuf_repository_service_worker/test__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+
+from repository_service_tuf_worker import (
+    Dynaconf,
+    get_repository_settings,
+    get_worker_settings,
+)
+
+
+class TestSettingsSetup:
+    def test_get_worker_settings(self):
+        worker_settings = get_worker_settings()
+        assert isinstance(worker_settings, Dynaconf)
+
+    def test_get_repository_settings(self):
+        repository_settings = get_repository_settings()
+        assert isinstance(repository_settings, Dynaconf)

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -14,7 +14,6 @@ from repository_service_tuf_worker.models import targets_schema
 
 class TestMetadataRepository:
     def test_basic_init(self):
-
         test_repo = repository.MetadataRepository()
         assert isinstance(test_repo, repository.MetadataRepository) is True
 
@@ -27,8 +26,7 @@ class TestMetadataRepository:
         test_repo.refresh_settings()
 
         assert (
-            test_repo._worker_settings.to_dict()
-            == repository.worker_settings.to_dict()
+            isinstance(test_repo._worker_settings, repository.Dynaconf) is True
         )
         assert isinstance(test_repo._settings, repository.Dynaconf) is True
 


### PR DESCRIPTION
Currently, repository.py and app.py use the worker and repository settings setup in repository_service_tuf_worker/__init__.py The way they are configured now (without a function/class directly in the module) means that when for the first time anything is imported from repository_service_tuf_worker/ it results in configuring the worker and repository settings.
As a side effect, this means that even if something is imported from repository_service_tuf_worker/ later this won't cause a new set of worker and repository settings to be set up.

This becomes a problem for our tests where in the test_repository.py and test_app.py modules we want to make sure that we have a new set of settings.
That is important because the worker and repository settings define the behavior of the repository.MetadataRepository object.

I fix that problem by just replacing the configuration of the settings to be done when a function is called instead of import.

**Note: this fix is required for #210.**

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>