### PR TITLE
Add the release tag latest as optional.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,11 @@ on:
         default: "latest"
         type: string
         required: False
-
+      latest_tag:
+         description: "Publish release as 'latest'"
+         default: True
+         type: boolean
+         required: False
 
 jobs:
   publish-container-image:
@@ -61,11 +65,16 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Add final tags
+    - name: Add release branch/tag name
       run: |
         docker pull ghcr.io/vmware/repository-service-tuf-worker:${{ github.sha }}
         docker tag ghcr.io/vmware/repository-service-tuf-worker:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
         docker push ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}
+
+    # The workflow triggered by push tag v* will be empty, because that we check != False
+    - name: Add release latest tag
+      if: ${{ inputs.latest_tag != false }}
+      run: |
         docker tag ghcr.io/vmware/repository-service-tuf-worker:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-worker:latest
         docker push ghcr.io/vmware/repository-service-tuf-worker:latest
 


### PR DESCRIPTION
It gives the flexibility to release or re-release new container images without adding them as a latest tag.

Reference implementation:
https://github.com/vmware/repository-service-tuf-api/pull/284