### PR TITLE
Update LocalStorage.get() to follow the interface & remove _load()

### DIFF
--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -78,7 +78,7 @@ class IStorage(ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def get(self, rolename: str, version: Optional[int]) -> "Metadata[T]":
+    def get(self, rolename: str, version: Optional[int]) -> Metadata[T]:
         """
         Return metadata from specific role name, optionally specific version
         (latest if None).

--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -78,9 +78,10 @@ class IStorage(ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def get(self, rolename: str, version: int) -> "Metadata[T]":
+    def get(self, rolename: str, version: Optional[int]) -> "Metadata[T]":
         """
-        Return metadata from specific role name, optionally specific version.
+        Return metadata from specific role name, optionally specific version
+        (latest if None).
         """
         raise NotImplementedError  # pragma: no cover
 

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -88,7 +88,7 @@ class MetadataRepository:
     def __init__(self):
         self._worker_settings = get_worker_settings()
         self._settings = get_repository_settings()
-        self._storage_backend = self.refresh_settings().STORAGE
+        self._storage_backend: IStorage = self.refresh_settings().STORAGE
         self._key_storage_backend = self.refresh_settings().KEYVAULT
         self._db = self.refresh_settings().SQL
         self._redis = redis.StrictRedis.from_url(
@@ -202,16 +202,6 @@ class MetadataRepository:
         self._worker_settings = settings
         return settings
 
-    def _load(self, role_name: str) -> Metadata:
-        """
-        Loads latest version of metadata for rolename using configured storage
-        backend.
-
-        NOTE: The storage backend is expected to translate rolenames to
-        filenames and figure out the latest version.
-        """
-        return Metadata.from_file(role_name, None, self._storage_backend)
-
     def _sign(self, role: Metadata, role_name: str) -> None:
         """
         Re-signs metadata with role-specific key from global key store.
@@ -273,7 +263,7 @@ class MetadataRepository:
             db_targets: RSTUTarget DB objects will be changed as published in
                 the DB SQL.
         """
-        timestamp = self._load(Timestamp.type)
+        timestamp = self._storage_backend.get(Timestamp.type)
         timestamp.signed.snapshot_meta = MetaFile(version=snapshot_version)
 
         self._bump_version(timestamp)
@@ -296,7 +286,7 @@ class MetadataRepository:
         bumps version and expiration, signs and persists. Returns new snapshot
         version, e.g. to update 'timestamp'.
         """
-        snapshot = self._load(Snapshot.type)
+        snapshot = self._storage_backend.get(Snapshot.type)
 
         for name, version in targets_meta:
             snapshot.signed.meta[f"{name}.json"] = MetaFile(version=version)
@@ -312,7 +302,7 @@ class MetadataRepository:
         """
         Return role name by target file path
         """
-        bin_role = self._load(Targets.type)
+        bin_role: Metadata[Targets] = self._storage_backend.get(Targets.type)
         bin_succinct_roles = bin_role.signed.delegations.succinct_roles
         bins_name = bin_succinct_roles.get_role_for_target(target_path)
 
@@ -456,7 +446,7 @@ class MetadataRepository:
                 # a new meta from the SQL DB.
                 # note: it might include targets from another parent task, it
                 # will speed up the process of publishing new targets.
-                role = self._load(rolename)
+                role: Metadata[Targets] = self._storage_backend.get(rolename)
                 role.signed.targets.clear()
                 role.signed.targets = {
                     target[0]: TargetFile.from_dict(target[1], target[0])
@@ -613,7 +603,7 @@ class MetadataRepository:
         Updating 'bins' also updates 'snapshot' and 'timestamp'.
         """
         try:
-            targets = self._load(Targets.type)
+            targets = self._storage_backend.get(Targets.type)
         except StorageError:
             logging.error(f"{Targets.type} not found, not bumping.")
             return False
@@ -621,7 +611,7 @@ class MetadataRepository:
         targets_succinct_roles = targets.signed.delegations.succinct_roles
         targets_meta = []
         for bins_name in targets_succinct_roles.get_roles():
-            bins_role = self._load(bins_name)
+            bins_role: Metadata[Targets] = self._storage_backend.get(bins_name)
 
             if (bins_role.signed.expires - datetime.now()) < timedelta(
                 hours=self._hours_before_expire
@@ -670,7 +660,7 @@ class MetadataRepository:
         """
 
         try:
-            snapshot = self._load(Snapshot.type)
+            snapshot = self._storage_backend.get(Snapshot.type)
         except StorageError:
             logging.error(f"{Snapshot.type} not found, not bumping.")
             return False

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -60,7 +60,7 @@ class LocalStorage(IStorage):
         file_object = None
         try:
             file_object = open(filename, "rb")
-            return Metadata.from_bytes(file_object)
+            return Metadata.from_bytes(file_object.read())
         except (OSError, DeserializationError) as e:
             raise StorageError(f"Can't open Role '{role}'") from e
         finally:

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -8,10 +8,10 @@ import stat
 from typing import List, Optional
 
 from securesystemslib.exceptions import StorageError  # noqa
+from tuf.api.metadata import Metadata, T, Timestamp
 from tuf.api.serialization import DeserializationError
 
 from repository_service_tuf_worker.interfaces import IStorage, ServiceSettings
-from repository_service_tuf_worker.repository import Metadata, Timestamp
 
 
 class LocalStorage(IStorage):
@@ -32,7 +32,7 @@ class LocalStorage(IStorage):
             ),
         ]
 
-    def get(self, role: str, version: Optional[int] = None) -> "Metadata":
+    def get(self, role: str, version: Optional[int] = None) -> Metadata[T]:
         """
         Returns TUF role metadata object for the passed role name, from the
         configured TUF repo path, optionally at the passed version (latest if

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -55,6 +55,7 @@ class TestLocalStorageService:
             )
         )
         fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
             close=pretend.call_recorder(lambda: None),
         )
         monkeypatch.setitem(
@@ -68,13 +69,14 @@ class TestLocalStorageService:
         result = service.get("root")
 
         assert result == expected_root
+        assert fake_file_obj.read.calls == [pretend.call()]
         assert fake_file_obj.close.calls == [pretend.call()]
         assert local.glob.glob.calls == [pretend.call("/path/2.root.json")]
         assert local.os.path.join.calls == [
             pretend.call(service._path, "*.root.json"),
             pretend.call(service._path, "2.root.json"),
         ]
-        assert local.Metadata.from_bytes.calls == [pretend.call(fake_file_obj)]
+        assert local.Metadata.from_bytes.calls == [pretend.call(None)]
 
     def test_get_timestamp(self, monkeypatch):
         service = local.LocalStorage("/path")
@@ -87,6 +89,7 @@ class TestLocalStorageService:
             )
         )
         fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
             close=pretend.call_recorder(lambda: None),
         )
         monkeypatch.setitem(
@@ -99,11 +102,12 @@ class TestLocalStorageService:
         result = service.get("timestamp")
 
         assert result == expected_timestamp
+        assert fake_file_obj.read.calls == [pretend.call()]
         assert fake_file_obj.close.calls == [pretend.call()]
         assert local.os.path.join.calls == [
             pretend.call(service._path, "timestamp.json"),
         ]
-        assert local.Metadata.from_bytes.calls == [pretend.call(fake_file_obj)]
+        assert local.Metadata.from_bytes.calls == [pretend.call(None)]
 
     def test_get_max_version_ValueError(self, monkeypatch):
         service = local.LocalStorage("/path")
@@ -118,6 +122,7 @@ class TestLocalStorageService:
             )
         )
         fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
             close=pretend.call_recorder(lambda: None),
         )
         monkeypatch.setitem(
@@ -133,13 +138,14 @@ class TestLocalStorageService:
         result = service.get("root")
 
         assert result == expected_root
+        assert fake_file_obj.read.calls == [pretend.call()]
         assert fake_file_obj.close.calls == [pretend.call()]
         assert local.os.path.join.calls == [
             pretend.call(service._path, "*.root.json"),
             pretend.call(service._path, "1.root.json"),
         ]
         assert local.glob.glob.calls == [pretend.call("/path/1.root.json")]
-        assert local.Metadata.from_bytes.calls == [pretend.call(fake_file_obj)]
+        assert local.Metadata.from_bytes.calls == [pretend.call(None)]
 
     def test_get_OSError(self, monkeypatch):
         service = local.LocalStorage("/path")

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -6,6 +6,7 @@ import os
 
 import pretend
 import pytest
+from tuf.api.metadata import Metadata, Root, Timestamp
 
 from repository_service_tuf_worker.services.storage import local
 
@@ -53,25 +54,27 @@ class TestLocalStorageService:
                 )
             )
         )
-        fake_file_object = pretend.stub(
+        fake_file_obj = pretend.stub(
             close=pretend.call_recorder(lambda: None),
-            read=pretend.call_recorder(lambda: b"fake_root_data"),
         )
         monkeypatch.setitem(
-            local.__builtins__, "open", lambda *a, **kw: fake_file_object
+            local.__builtins__, "open", lambda *a: fake_file_obj
         )
 
-        with service.get("root") as r:
-            result = r.read()
+        expected_root = Metadata(Root())
+        local.Metadata = pretend.stub(
+            from_bytes=pretend.call_recorder(lambda *a: expected_root)
+        )
+        result = service.get("root")
 
-        assert result == fake_file_object.read()
-        assert fake_file_object.close.calls == [pretend.call()]
-        assert fake_file_object.read.calls == [pretend.call(), pretend.call()]
+        assert result == expected_root
+        assert fake_file_obj.close.calls == [pretend.call()]
         assert local.glob.glob.calls == [pretend.call("/path/2.root.json")]
         assert local.os.path.join.calls == [
             pretend.call(service._path, "*.root.json"),
             pretend.call(service._path, "2.root.json"),
         ]
+        assert local.Metadata.from_bytes.calls == [pretend.call(fake_file_obj)]
 
     def test_get_timestamp(self, monkeypatch):
         service = local.LocalStorage("/path")
@@ -83,23 +86,24 @@ class TestLocalStorageService:
                 )
             )
         )
-        fake_file_object = pretend.stub(
+        fake_file_obj = pretend.stub(
             close=pretend.call_recorder(lambda: None),
-            read=pretend.call_recorder(lambda: b"fake_root_data"),
         )
         monkeypatch.setitem(
-            local.__builtins__, "open", lambda *a, **kw: fake_file_object
+            local.__builtins__, "open", lambda *a: fake_file_obj
         )
+        expected_timestamp = Metadata(Timestamp())
+        local.Metadata = pretend.stub(
+            from_bytes=pretend.call_recorder(lambda *a: expected_timestamp)
+        )
+        result = service.get("timestamp")
 
-        with service.get("timestamp") as r:
-            result = r.read()
-
-        assert result == fake_file_object.read()
-        assert fake_file_object.close.calls == [pretend.call()]
-        assert fake_file_object.read.calls == [pretend.call(), pretend.call()]
+        assert result == expected_timestamp
+        assert fake_file_obj.close.calls == [pretend.call()]
         assert local.os.path.join.calls == [
             pretend.call(service._path, "timestamp.json"),
         ]
+        assert local.Metadata.from_bytes.calls == [pretend.call(fake_file_obj)]
 
     def test_get_max_version_ValueError(self, monkeypatch):
         service = local.LocalStorage("/path")
@@ -113,28 +117,29 @@ class TestLocalStorageService:
                 )
             )
         )
-        fake_file_object = pretend.stub(
+        fake_file_obj = pretend.stub(
             close=pretend.call_recorder(lambda: None),
-            read=pretend.call_recorder(lambda: b"fake_root_data"),
         )
         monkeypatch.setitem(
             local.__builtins__, "max", pretend.raiser(ValueError)
         )
         monkeypatch.setitem(
-            local.__builtins__, "open", lambda *a, **kw: fake_file_object
+            local.__builtins__, "open", lambda *a: fake_file_obj
         )
+        expected_root = Metadata(Root())
+        local.Metadata = pretend.stub(
+            from_bytes=pretend.call_recorder(lambda *a: expected_root)
+        )
+        result = service.get("root")
 
-        with service.get("root") as r:
-            result = r.read()
-
-        assert result == fake_file_object.read()
-        assert fake_file_object.close.calls == [pretend.call()]
-        assert fake_file_object.read.calls == [pretend.call(), pretend.call()]
+        assert result == expected_root
+        assert fake_file_obj.close.calls == [pretend.call()]
         assert local.os.path.join.calls == [
             pretend.call(service._path, "*.root.json"),
             pretend.call(service._path, "1.root.json"),
         ]
         assert local.glob.glob.calls == [pretend.call("/path/1.root.json")]
+        assert local.Metadata.from_bytes.calls == [pretend.call(fake_file_obj)]
 
     def test_get_OSError(self, monkeypatch):
         service = local.LocalStorage("/path")


### PR DESCRIPTION
Make sure that LocalStorage.get() and IStorage.get() return the same
type: Metadata[T].
Currently, the LocalStorage.get() behaves like a context manager and
returns "BufferedReader" without a good reason for that and doesn't
follow what the interface has defined as a return type - Metadata[T].

Additionally, I am removing repository._load() as we are making a mistake in passing
self.storagebackend() as an argument to "Metadata.from_file()" where it
expects an object from the type securesystemslib.StorageBackendInterface
but our self._storagebackend() doesn't implement that interface.
Finally, there are more checks made inside LocalStorage.get()
and this will allow us to be more flexible when we introduce other
storage services.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>