### PR TITLE
Generate online roles metadata during bootstrap

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -422,13 +422,12 @@ class MetadataRepository:
         snapshot: Metadata[Snapshot] = Metadata(Snapshot())
         timestamp: Metadata[Timestamp] = Metadata(Timestamp())
 
-        # Succinct delegated roles (`bins`)
-        succinct_roles = SuccinctRoles(
-            [],
-            1,
-            int(log(tuf_settings["services"]["number_of_delegated_bins"], 2)),
-            BINS,
+        # Calculate the bit length (Number of bits between 1 and 32)
+        bit_length = int(
+            log(tuf_settings["services"]["number_of_delegated_bins"], 2)
         )
+        # Succinct delegated roles (`bins`)
+        succinct_roles = SuccinctRoles([], 1, bit_length, BINS)
         targets.signed.delegations = Delegations(
             keys={}, succinct_roles=succinct_roles
         )

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -411,7 +411,7 @@ class MetadataRepository:
             raise KeyError("No 'metadata' in the payload")
 
         # Saves the `Root` metadata in the backend storage service and returns
-        # online public key (it uses the `Timestamp` key as reference)
+        # the online public key (it uses the `Timestamp` key as reference)
         root: Metadata[Root] = Metadata.from_dict(root_metadata[Root.type])
         self._persist(root, Root.type)
         _keyid: str = root.signed.roles[Timestamp.type].keyids[0]
@@ -433,7 +433,7 @@ class MetadataRepository:
             keys={}, succinct_roles=succinct_roles
         )
         # Initialize all succinct delegated roles (`bins`), update expire,
-        # sign, add to `Snapshot` meta and persiste in the backend storage
+        # sign, add to `Snapshot` meta and persist in the backend storage
         # service.
         for delegated_name in succinct_roles.get_roles():
             targets.signed.add_key(

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -8,7 +8,8 @@ import logging
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple
+from math import log
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import redis
 from celery.app.task import Task
@@ -17,10 +18,13 @@ from celery.result import AsyncResult, states
 from securesystemslib.exceptions import StorageError  # type: ignore
 from tuf.api.metadata import (  # noqa
     SPECIFICATION_VERSION,
+    Delegations,
+    Key,
     Metadata,
     MetaFile,
     Root,
     Snapshot,
+    SuccinctRoles,
     TargetFile,
     Targets,
     Timestamp,
@@ -226,20 +230,19 @@ class MetadataRepository:
 
         bytes_data = role.to_bytes(JSONSerializer())
         self._storage_backend.put(bytes_data, filename)
-
+        logging.debug(f"{filename} saved")
         return filename
 
-    def _bump_expiry(self, role: Metadata, expiry_id: str) -> None:
+    def _bump_expiry(self, role: Metadata, role_name: str) -> None:
         """
         Bumps metadata expiration date by role-specific interval.
-
-        The metadata role type is used as default expiry id. This is only
-        allowed for top-level roles.
         """
         role.signed.expires = datetime.now().replace(
             microsecond=0
         ) + timedelta(
-            days=int(self._settings.get_fresh(f"{expiry_id}_EXPIRATION"))
+            days=int(
+                self._settings.get_fresh(f"{role_name.upper()}_EXPIRATION")
+            )
         )
 
     def _bump_version(self, role: Metadata) -> None:
@@ -398,23 +401,66 @@ class MetadataRepository:
     ) -> Dict[str, Any]:
         """
         Bootstrap the Metadata Repository
-
-        Add the online Keys to the Key Storage backend and the Signed Metadata
-        to the Storage Backend.
         """
-        if payload.get("settings") is None:
-            raise ValueError("No settings in the payload")
+        tuf_settings = payload.get("settings")
+        if tuf_settings is None:
+            raise KeyError("No 'settings' in the payload")
 
-        metadata = payload.get("metadata")
-        if metadata is None:
-            raise (ValueError("No metadata in the payload"))
+        root_metadata = payload.get("metadata")
+        if root_metadata is None:
+            raise KeyError("No 'metadata' in the payload")
 
-        for role_name, data in metadata.items():
-            metadata = Metadata.from_dict(data)
-            self._persist(metadata, role_name)
-            logging.debug(f"{role_name}.json saved")
+        # Saves the `Root` metadata in the backend storage service and returns
+        # online public key (it uses the `Timestamp` key as reference)
+        root: Metadata[Root] = Metadata.from_dict(root_metadata[Root.type])
+        self._persist(root, Root.type)
+        _keyid: str = root.signed.roles[Timestamp.type].keyids[0]
+        public_key = root.signed.keys[_keyid]
 
-        self.bump_online_roles()
+        # Top level roles (`Targets`, `Timestamp``, `Snapshot`) initialization
+        targets: Metadata[Targets] = Metadata(Targets())
+        snapshot: Metadata[Snapshot] = Metadata(Snapshot())
+        timestamp: Metadata[Timestamp] = Metadata(Timestamp())
+
+        # Succinct delegated roles (`bins`)
+        succinct_roles = SuccinctRoles(
+            [],
+            1,
+            int(log(tuf_settings["services"]["number_of_delegated_bins"], 2)),
+            BINS,
+        )
+        targets.signed.delegations = Delegations(
+            keys={}, succinct_roles=succinct_roles
+        )
+        # Initialize all succinct delegated roles (`bins`), update expire,
+        # sign, add to `Snapshot` meta and persiste in the backend storage
+        # service.
+        for delegated_name in succinct_roles.get_roles():
+            targets.signed.add_key(
+                Key.from_securesystemslib_key(
+                    self._key_storage_backend.get(public_key).key_dict
+                ),
+                delegated_name,
+            )
+            bins_role = Metadata(Targets())
+            self._bump_expiry(bins_role, BINS)
+            self._sign(bins_role)
+            snapshot.signed.meta[f"{delegated_name}.json"] = MetaFile(
+                version=bins_role.signed.version
+            )
+            self._persist(bins_role, delegated_name)
+
+        # Update `Snapshot` meta with targets
+        snapshot.signed.meta[f"{Targets.type}.json"] = MetaFile(
+            version=targets.signed.version
+        )
+
+        # Update expire, sign and persist the top level roles (`Targets`,
+        # `Timestamp``, `Snapshot`) in the backend storage service.
+        for role in [targets, snapshot, timestamp]:
+            self._bump_expiry(role, role.signed.type)
+            self._sign(role)
+            self._persist(role, role.signed.type)
 
         result = ResultDetails(
             status="Task finished.",

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from math import log
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import redis
 from celery.app.task import Task

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -451,7 +451,8 @@ class TestMetadataRepository:
 
         # Special checks as calls use metadata object instances
 
-        # Assert that calls contain two args and 'role' argument is a 'Metadata'.
+        # Assert that calls contain two args and 'role' argument is a
+        # 'Metadata'.
         for call in test_repo._bump_expiry.calls:
             assert len(call.args) == 2
             assert isinstance(call.args[0], repository.Metadata)
@@ -467,8 +468,8 @@ class TestMetadataRepository:
             "timestamp",
         ]
 
-        # Assert that calls use two args and 'role' argument is a 'Metadata' type or
-        # a pretend.sub()
+        # Assert that calls use two args and 'role' argument is a 'Metadata'
+        # type or a pretend.sub()
         for call in test_repo._persist.calls:
             assert len(call.args) == 2
             assert isinstance(

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -449,6 +449,54 @@ class TestMetadataRepository:
             pretend.call("online_public_key"),
         ]
 
+        # Special checks as it uses Metadata as dynamic instance
+
+        # Assert that contains two args and 'role' argument is a 'Metadata'.
+        for call in test_repo._bump_expiry.calls:
+            assert len(call.args) == 2
+            assert isinstance(call.args[0], repository.Metadata)
+        # Assert the test_repo._bump_expiry calls role_name argument
+        _bump_expiry_role_names = [
+            call.args[1] for call in test_repo._bump_expiry.calls
+        ]
+        assert _bump_expiry_role_names == [
+            "bins",
+            "bins",
+            "targets",
+            "snapshot",
+            "timestamp",
+        ]
+
+        # Assert that contains two args and 'role' argument is a 'Metadata' or
+        # a pretend.sub()
+        for call in test_repo._persist.calls:
+            assert len(call.args) == 2
+            assert isinstance(
+                call.args[0], (repository.Metadata, pretend.stub)
+            )
+        # Assert the test_repo._persist calls role_name argument
+        _persist_persist_role_names = [
+            call.args[1] for call in test_repo._persist.calls
+        ]
+        assert _persist_persist_role_names == [
+            "root",
+            "bins-0",
+            "bins-1",
+            "targets",
+            "snapshot",
+            "timestamp",
+        ]
+
+        # The role argument is instance which doesn't allows us to check the
+        # object itself
+        for call in test_repo._sign.calls:
+            assert len(call.args) == 1
+            assert isinstance(call.args[0], repository.Metadata)
+        # Assert the number of calls test_repos._sign excluding root which we
+        # don't sign in the worker bootstrap process. This check guarantes that
+        # we all signed metadata is persisted.
+        assert len(test_repo._sign.calls) == len(test_repo._persist.calls) - 1
+
     def test_bootstrap_missing_settings(self, test_repo):
         payload = {
             "metadata": {

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -449,9 +449,9 @@ class TestMetadataRepository:
             pretend.call("online_public_key"),
         ]
 
-        # Special checks as it uses Metadata as dynamic instance
+        # Special checks as calls use metadata object instances
 
-        # Assert that contains two args and 'role' argument is a 'Metadata'.
+        # Assert that calls contain two args and 'role' argument is a 'Metadata'.
         for call in test_repo._bump_expiry.calls:
             assert len(call.args) == 2
             assert isinstance(call.args[0], repository.Metadata)
@@ -467,7 +467,7 @@ class TestMetadataRepository:
             "timestamp",
         ]
 
-        # Assert that contains two args and 'role' argument is a 'Metadata' or
+        # Assert that calls use two args and 'role' argument is a 'Metadata' type or
         # a pretend.sub()
         for call in test_repo._persist.calls:
             assert len(call.args) == 2
@@ -487,14 +487,14 @@ class TestMetadataRepository:
             "timestamp",
         ]
 
-        # The role argument is instance which doesn't allows us to check the
+        # The role argument is an instance we cannot check the object itself
         # object itself
         for call in test_repo._sign.calls:
             assert len(call.args) == 1
             assert isinstance(call.args[0], repository.Metadata)
         # Assert the number of calls test_repos._sign excluding root which we
-        # don't sign in the worker bootstrap process. This check guarantes that
-        # we all signed metadata is persisted.
+        # don't sign during the worker bootstrap process. This check guarantees
+        # that all signed metadata is persisted.
         assert len(test_repo._sign.calls) == len(test_repo._persist.calls) - 1
 
     def test_bootstrap_missing_settings(self, test_repo):


### PR DESCRIPTION
Generate metadata for `Targets`, `Snapshot`, `Timestamp` and succinct delegated roles (`bins`) using online key during the bootstrap process.

This implementation is part of bootstrap simplification.

The Worker will receive only the root metadata and build all the roles that uses the online key.

Closes #168.