### PR TITLE
Add a way to handle exceptions LockNotOwnedError

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -109,6 +109,17 @@ Available types:
     - Requires variable ``RSTUF_LOCAL_STORAGE_BACKEND_PATH``
       - Define the directory where the data will be saved, example: `storage`
 
+#### (Optional) `RSTUF_LOCK_TIMEOUT`
+
+Timeout for publishing JSON metadata files. Default: 60.0 (seconds)
+
+This timeout avoids race conditions publishing JSON metadata files by multiple
+Worker's services. It guarantees that the metadata is consistent in the backend
+storage service (`RSTUF_STORAGE_BACKEND`).
+
+
+Mostly in use cases, the timeout of 60.0 seconds is sufficient.
+
 #### (Required) `RSTUF_KEYVAULT_BACKEND`
 
 Select a supported type of Key Vault Service.
@@ -132,13 +143,14 @@ Available types:
 
 Container data directory. Default: `/data`
 
+
 ### Persistent data
 
 * `$DATA_DIR`. Default: `/data`
 
 ### Customization/Tuning
 
-The `repository-service-tuf-worker` uses supervisord and uses a `supervisor.conf`
-from `$DATA_DIR`.
+The `repository-service-tuf-worker` uses supervisord and uses a
+`supervisor.conf` from `$DATA_DIR`.
 
 It can be used to customize/tuning performance of Celery.

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -476,52 +476,66 @@ class MetadataRepository:
         Publish targets from SQL DB as persistent TUF Metadata in the backend
         storage.
         """
-
-        # lock to avoid race conditions
-        with self._redis.lock("publish_targets", timeout=5.0):
-            # get all delegated role names with unpublished targets
-            unpublished_roles = targets_crud.read_unpublished_rolenames(
-                self._db
-            )
-
-            if len(unpublished_roles) == 0:
-                logging.debug("No new targets in delegated roles. Finishing")
-                return None
-
-            # initialize the new snapshot targets meta and published targets
-            # from DB SQL
-            new_snapshot_meta: List[Tuple(str, int)] = []
-            db_published_targets: List[str] = []
-            for _, rolename in unpublished_roles:
-                # get the unpublished targets for the delegated, it will be use
-                # to update the database when Snapshot and Timestamp is
-                # published by `_update_timestamp`
-                db_targets = targets_crud.read_unpublished_by_rolename(
-                    db=self._db, rolename=rolename
+        timeout = int(self.refresh_settings().get("LOCK_TIMEOUT", 60.0))
+        logging.debug(f"Configured timeout: {timeout}")
+        lock_finished = False
+        # Lock to avoid race conditions. See `LOCK_TIMEOUT` in the Worker guide
+        # documentation.
+        try:
+            with self._redis.lock("LOCK_TARGETS", timeout=timeout):
+                # get all delegated role names with unpublished targets
+                unpublished_roles = targets_crud.read_unpublished_rolenames(
+                    self._db
                 )
-                logging.debug(f"{rolename}: New targets #: {len(db_targets)}")
-                db_published_targets += [target.path for target in db_targets]
-
-                # load the delegated targets role, clean the targets and add
-                # a new meta from the SQL DB.
-                # note: it might include targets from another parent task, it
-                # will speed up the process of publishing new targets.
-                role: Metadata[Targets] = self._storage_backend.get(rolename)
-                role.signed.targets.clear()
-                role.signed.targets = {
-                    target[0]: TargetFile.from_dict(target[1], target[0])
-                    for target in targets_crud.read_all_add_by_rolename(
-                        self._db, rolename
+                if len(unpublished_roles) == 0:
+                    logging.debug(
+                        "No new targets in delegated roles. Finishing"
                     )
-                }
+                    return None
 
-                # update expiry, bump version and persist to the storage
-                self._bump_expiry(role, BINS)
-                self._bump_version(role)
-                self._sign(role)
-                self._persist(role, rolename)
-                # append to the new snapshot targets meta
-                new_snapshot_meta.append((rolename, role.signed.version))
+                # initialize the new snapshot targets meta and published
+                # targets from DB SQL
+                new_snapshot_meta: List[Tuple(str, int)] = []
+                db_published_targets: List[str] = []
+                for _, rolename in unpublished_roles:
+                    # get the unpublished targets for the delegated, it will be
+                    # use to update the database when Snapshot and Timestamp is
+                    # published by `_update_timestamp`
+                    db_targets = targets_crud.read_unpublished_by_rolename(
+                        db=self._db, rolename=rolename
+                    )
+                    logging.debug(
+                        f"{rolename}: New targets #: {len(db_targets)}"
+                    )
+                    db_published_targets += [
+                        target.path for target in db_targets
+                    ]
+
+                    # load the delegated targets role, clean the targets and
+                    # add a new meta from the SQL DB.
+                    # note: it might include targets from another parent task,
+                    # it will speed up the process of publishing new targets.
+                    role: Metadata[Targets] = self._storage_backend.get(
+                        rolename
+                    )
+                    role.signed.targets.clear()
+                    role.signed.targets = {
+                        target[0]: TargetFile.from_dict(target[1], target[0])
+                        for target in targets_crud.read_all_add_by_rolename(
+                            self._db, rolename
+                        )
+                    }
+
+                    # update expiry, bump version and persist to the storage
+                    self._bump_expiry(role, BINS)
+                    self._bump_version(role)
+                    self._sign(role)
+                    self._persist(role, rolename)
+                    # append to the new snapshot targets meta
+                    new_snapshot_meta.append((rolename, role.signed.version))
+
+                # context lock finished
+                lock_finished = True
 
             # update snapshot and timestamp
             # note: the `db_published_targets` contains the targets that
@@ -531,6 +545,28 @@ class MetadataRepository:
                 self._update_snapshot(new_snapshot_meta),
                 db_published_targets,
             )
+
+        except redis.exceptions.LockNotOwnedError:
+            # The LockNotOwnedError happens when the task exceeds the timeout,
+            # and another task owns the lock.
+            # If the task time out, the lock is released. If it doesn't finish
+            # properly, it will raise (fail) the task. Otherwise, the ignores
+            # the error because another task didn't lock it.
+            if lock_finished is False:
+                logging.error("The task to publish targets exceeded timeout")
+                raise redis.exceptions.LockError(
+                    f"RSTUF: Task exceed `LOCK_TIMEOUT` ({timeout} seconds)"
+                )
+
+        result = ResultDetails(
+            states.SUCCESS,
+            details={
+                "target_roles": [meta[0] for meta in new_snapshot_meta],
+            },
+            last_update=datetime.now(),
+        )
+        logging.debug("Targets published.")
+        return asdict(result)
 
     def add_targets(
         self, payload: Dict[str, Any], update_state: Task.update_state
@@ -758,14 +794,36 @@ class MetadataRepository:
 
     def bump_online_roles(self) -> bool:
         """Bump online Roles (Snapshot, Timestamp, BINS)."""
-        with self._redis.lock("TUF_SNAPSHOT_TIMESTAMP"):
-            if self._settings.get_fresh("BOOTSTRAP") is None:
-                logging.info(
-                    "[automatic_version_bump] No bootstrap, skipping..."
+        timeout = int(self.refresh_settings().get("LOCK_TIMEOUT", 60.0))
+        logging.debug(f"Configured timeout: {timeout}")
+        lock_finished = False
+        # Lock to avoid race conditions. See `LOCK_TIMEOUT` in the Worker guide
+        # documentation.
+        try:
+            with self._redis.lock("LOCK_SNAPSHOT_TIMESTAMP", timeout=timeout):
+                if self._settings.get_fresh("BOOTSTRAP") is None:
+                    logging.info(
+                        "[automatic_version_bump] No bootstrap, skipping..."
+                    )
+                    return False
+
+                self.bump_snapshot()
+                self.bump_bins_roles()
+
+            lock_finished = True
+        except redis.exceptions.LockNotOwnedError:
+            # The LockNotOwnedError happens when the task exceeds the timeout,
+            # and another task owns the lock.
+            # If the task time out, the lock is released. If it doesn't finish
+            # properly, it will raise (fail) the task. Otherwise, the ignores
+            # the error because another task didn't lock it.
+            if lock_finished is False:
+                logging.error(
+                    "The task to bump Timestamp, Snapshot, and BINS exceeded "
+                    "timeout."
                 )
-                return False
+                raise redis.exceptions.LockError(
+                    f"RSTUF: Task exceed `LOCK_TIMEOUT` ({timeout} seconds)"
+                )
 
-            self.bump_snapshot()
-            self.bump_bins_roles()
-
-            return True
+        return True

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -521,6 +521,14 @@ class TestMetadataRepository:
         assert "No 'metadata' in the payload" in str(err)
 
     def test_publish_targets(self, test_repo, monkeypatch):
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_worker.repository.datetime", fake_datetime
+        )
+
         @contextmanager
         def mocked_lock(lock, timeout):
             yield lock, timeout
@@ -583,9 +591,17 @@ class TestMetadataRepository:
 
         test_result = test_repo.publish_targets()
 
-        assert test_result is None
+        assert test_result == repository.asdict(
+            repository.ResultDetails(
+                states.SUCCESS,
+                details={
+                    "target_roles": ["bins-0", "bins-e"],
+                },
+                last_update=fake_time,
+            )
+        )
         assert test_repo._redis.lock.calls == [
-            pretend.call("publish_targets", timeout=5.0)
+            pretend.call("LOCK_TARGETS", timeout=60.0)
         ]
         assert fake_crud_read_unpublished_rolenames.calls == [
             pretend.call(test_repo._db)
@@ -629,6 +645,23 @@ class TestMetadataRepository:
             )
         ]
 
+    def test_publish_targets_exception_LockNotOwnedError(self, test_repo):
+        @contextmanager
+        def mocked_lock(lock, timeout):
+            raise repository.redis.exceptions.LockNotOwnedError("timeout")
+
+        test_repo._redis = pretend.stub(
+            lock=pretend.call_recorder(mocked_lock)
+        )
+
+        with pytest.raises(repository.redis.exceptions.LockError) as e:
+            test_repo.publish_targets()
+
+        assert "RSTUF: Task exceed `LOCK_TIMEOUT` (60 seconds)" in str(e)
+        assert test_repo._redis.lock.calls == [
+            pretend.call("LOCK_TARGETS", timeout=60)
+        ]
+
     def test_publish_targets_without_targets_to_publish(
         self, test_repo, monkeypatch
     ):
@@ -654,7 +687,7 @@ class TestMetadataRepository:
 
         assert test_result is None
         assert test_repo._redis.lock.calls == [
-            pretend.call("publish_targets", timeout=5.0)
+            pretend.call("LOCK_TARGETS", timeout=60.0)
         ]
         assert fake_crud_read_unpublished_rolenames.calls == [
             pretend.call(test_repo._db)
@@ -1357,8 +1390,8 @@ class TestMetadataRepository:
 
     def test_bump_online_roles(self, test_repo):
         @contextmanager
-        def mocked_lock(lock):
-            yield lock
+        def mocked_lock(lock, timeout):
+            yield lock, timeout
 
         test_repo._redis = pretend.stub(
             lock=pretend.call_recorder(mocked_lock)
@@ -1372,7 +1405,7 @@ class TestMetadataRepository:
         result = test_repo.bump_online_roles()
         assert result is True
         assert test_repo._redis.lock.calls == [
-            pretend.call("TUF_SNAPSHOT_TIMESTAMP")
+            pretend.call("LOCK_SNAPSHOT_TIMESTAMP", timeout=60)
         ]
         assert test_repo._settings.get_fresh.calls == [
             pretend.call("BOOTSTRAP")
@@ -1382,8 +1415,8 @@ class TestMetadataRepository:
 
     def test_bump_online_roles_when_no_bootstrap(self, test_repo):
         @contextmanager
-        def mocked_lock(lock):
-            yield lock
+        def mocked_lock(lock, timeout):
+            yield lock, timeout
 
         test_repo._redis = pretend.stub(
             lock=pretend.call_recorder(mocked_lock)
@@ -1395,8 +1428,24 @@ class TestMetadataRepository:
         result = test_repo.bump_online_roles()
         assert result is False
         assert test_repo._redis.lock.calls == [
-            pretend.call("TUF_SNAPSHOT_TIMESTAMP")
+            pretend.call("LOCK_SNAPSHOT_TIMESTAMP", timeout=60)
         ]
         assert test_repo._settings.get_fresh.calls == [
             pretend.call("BOOTSTRAP")
+        ]
+
+    def test_bump_online_roles_exception_LockNotOwnedError(self, test_repo):
+        @contextmanager
+        def mocked_lock(lock, timeout):
+            raise repository.redis.exceptions.LockNotOwnedError("timeout")
+
+        test_repo._redis = pretend.stub(
+            lock=pretend.call_recorder(mocked_lock)
+        )
+        with pytest.raises(repository.redis.exceptions.LockError) as e:
+            test_repo.bump_online_roles()
+
+        assert "RSTUF: Task exceed `LOCK_TIMEOUT` (60 seconds)" in str(e)
+        assert test_repo._redis.lock.calls == [
+            pretend.call("LOCK_SNAPSHOT_TIMESTAMP", timeout=60)
         ]


### PR DESCRIPTION
It adds a better way to handle the LockNotOwnedError exception.

The LockNotOwnedError happens when the task exceeds the timeout, and another task owns the lock.
If the task time out, the lock is released. If it doesn't finish properly, it will raise (fail) the task. Otherwise, the ignores the error because another task didn't lock it.
Closes #151 

The lock is now an optional configurable setting during the container deployment.
Closes #22

The publish targets also return the task properly when finished.
Closes #204