### PR TITLE
hotfix: wrong call after refactoring bump_bins_roles

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -838,7 +838,7 @@ class MetadataRepository:
                     )
                     return False
 
-                self.bump_bins_roles()
+                self.bump_target_roles()
 
             status_lock_timestamp = True
         except redis.exceptions.LockNotOwnedError:

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -1552,7 +1552,7 @@ class TestMetadataRepository:
         test_repo._settings = pretend.stub(
             get_fresh=pretend.call_recorder(lambda *a: "fake_bootstrap_id")
         )
-        test_repo.bump_bins_roles = pretend.call_recorder(lambda: None)
+        test_repo.bump_target_roles = pretend.call_recorder(lambda: None)
 
         result = test_repo.bump_online_roles()
         assert result is True
@@ -1562,7 +1562,7 @@ class TestMetadataRepository:
         assert test_repo._settings.get_fresh.calls == [
             pretend.call("BOOTSTRAP")
         ]
-        assert test_repo.bump_bins_roles.calls == [pretend.call()]
+        assert test_repo.bump_target_roles.calls == [pretend.call()]
 
     def test_bump_online_roles_when_no_bootstrap(self, test_repo):
         @contextmanager


### PR DESCRIPTION
This fix an old call using refactored `bump_bin_roles`