### PR TITLE
Release v0.1.0a3

### DIFF
--- a/repository_service_tuf_worker/__version__.py
+++ b/repository_service_tuf_worker/__version__.py
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-version = "0.1.0a2"
+version = "0.1.0a3"
 copyright = "Copyright (c) 2022-2023 VMware Inc"
 author = "Kairo de Araujo"


### PR DESCRIPTION
Implements a hotfix for the automated bumping versions for the expired metadata (roles that uses online keys)